### PR TITLE
fix(runners): lazy-import torch in blend_modes so CI collects without…

### DIFF
--- a/runners/blend_modes.py
+++ b/runners/blend_modes.py
@@ -1,5 +1,14 @@
+from __future__ import annotations
 
-import torch
+
+class _LazyTorch:
+    def __getattr__(self, name):
+        import torch as _torch
+        globals()['torch'] = _torch
+        return getattr(_torch, name)
+
+
+torch = _LazyTorch()
 
 
 def _multiply(A, B, a, b):

--- a/tests/test_audio_pro_stages.py
+++ b/tests/test_audio_pro_stages.py
@@ -431,6 +431,7 @@ class TestSegments:
 
 class TestConvolve:
     def test_delta_ir_is_identity(self):
+        pytest.importorskip("scipy")
         from ComfyTV.runners.audio_dsp import _write_wav, convolve_ir
         from ComfyTV.runners.media import _AUDIO_RATE, _decode_audio_to_array, localize
         t = np.arange(int(0.3 * _AUDIO_RATE)) / _AUDIO_RATE
@@ -452,6 +453,7 @@ class TestConvolve:
 
 class TestSweepDeconvolve:
     def test_roundtrip_gives_impulse(self, monkeypatch):
+        pytest.importorskip("scipy")
         from ComfyTV.runners.audio_dsp import deconvolve_ir, ess_sweep
         from ComfyTV.runners.media import _AUDIO_RATE, _decode_audio_to_array, localize
         sweep_url = ess_sweep(duration_s=1.0, fmin=20.0, fmax=8000.0,

--- a/tests/test_natron_alignment.py
+++ b/tests/test_natron_alignment.py
@@ -101,6 +101,7 @@ def _bright_centroid(url):
 
 class TestScreenDirections:
     def test_translate_y_positive_moves_up(self):
+        pytest.importorskip("torch")
         import folder_paths
         from ComfyTV.runners import media
         from ComfyTV.runners.media_torch import transform_video
@@ -116,6 +117,7 @@ class TestScreenDirections:
 
     def test_rotation_positive_is_ccw(self):
         """+90°: a dot right of center must end ABOVE the center (CCW)."""
+        pytest.importorskip("torch")
         import folder_paths
         from ComfyTV.runners import media
         from ComfyTV.runners.media_torch import transform_video
@@ -150,6 +152,7 @@ class TestMergeMixSemantics:
         """Natron mix: out = lerp(B, multiply(A,B), 0.5).
         gray-0.5 fg × white bg = 0.5; lerp(1.0, 0.5, 0.5) = 0.75 (~191).
         The old premultiplied-attenuation gave ~0.25 (~64)."""
+        pytest.importorskip("torch")
         import folder_paths
         from ComfyTV.runners import media
         from ComfyTV.runners.media_torch import composite_videos
@@ -175,6 +178,7 @@ class TestTrackerConfidence:
     def test_confidence_reported_and_blank_holds(self):
         """A featureless black clip yields near-zero confidence and the
         track HOLDS its position instead of wandering."""
+        pytest.importorskip("torch")
         import json
         import folder_paths
         from ComfyTV.runners import media

--- a/tests/test_r3_stages.py
+++ b/tests/test_r3_stages.py
@@ -40,6 +40,7 @@ def test_meta_registered():
 
 
 def test_extension_registers_all():
+    pytest.importorskip("torch")
     import asyncio
     from ComfyTV.nodes.stages import ComfyTVExtension
     nodes = asyncio.run(ComfyTVExtension().get_node_list())

--- a/tests/test_video_p2.py
+++ b/tests/test_video_p2.py
@@ -128,6 +128,7 @@ class TestPaint:
         ])
 
     def test_no_strokes_rejected(self, clip_b):
+        pytest.importorskip("torch")
         from ComfyTV.runners.paint import paint_video
         with pytest.raises(RuntimeError, match="no strokes"):
             paint_video(clip_b, [])


### PR DESCRIPTION
… torch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Deferred loading of the PyTorch dependency until it is actually needed, improving startup behavior when it isn’t used immediately.
* **Compatibility**
  * Test coverage now automatically skips SciPy- and PyTorch-dependent tests when those dependencies are unavailable, avoiding failures in minimal environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->