### PR TITLE
fix: upgrade postcss to 8.5.18 (GHSA-r28c-9q8g-f849)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "marked": "^18.0.6",
     "opensheetmusicdisplay": "^2.1.0",
     "pinia": "^3.0.4",
+    "postcss": "8.5.18",
     "reka-ui": "^2.9.9",
     "three": "^0.184.0",
     "tippy.js": "^6.3.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       pinia:
         specifier: ^3.0.4
         version: 3.0.4(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3))
+      postcss:
+        specifier: 8.5.18
+        version: 8.5.18
       reka-ui:
         specifier: ^2.9.9
         version: 2.9.9(vue@3.5.35(typescript@5.9.3))
@@ -1790,8 +1793,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -2955,7 +2958,7 @@ snapshots:
       '@vue/shared': 3.5.35
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.15
+      postcss: 8.5.18
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.35':
@@ -3874,7 +3877,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.15:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -4333,7 +4336,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.18
       rollup: 4.61.1
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary
Upgrade postcss from 8.5.15 to 8.5.18 to fix GHSA-r28c-9q8g-f849.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | GHSA-r28c-9q8g-f849 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `GHSA-r28c-9q8g-f849` |
| **File** | `package-lock.json` |
| **Assessment** | Pattern match — needs manual review |

**Description**: PostCSS: Path Traversal in Previous Source Map Auto-Loading (sourceMappingURL) leads to Arbitrary .map File Disclosure

## Evidence

**Scanner confirmation**: trivy rule `GHSA-r28c-9q8g-f849` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web application - XSS and injection vulnerabilities can affect end users.

## Changes
- `package.json`
- `pnpm-lock.yaml`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for PostCSS 8.5.18 to improve compatibility with the application’s styling toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->