### PR TITLE
fix: repoint workflow rows when the user directory itself moves

### DIFF
--- a/runners/workflow_db/seed.py
+++ b/runners/workflow_db/seed.py
@@ -112,24 +112,87 @@ def _sync_legacy_workflows(root: Path) -> tuple[list[str], list[str]]:
     return copied, updated
 
 
+def _marker_rel(p: Path, parent_marker: str) -> Optional[Path]:
+    parts = p.parts
+    for i in range(len(parts) - 2, 0, -1):
+        if parts[i].lower() == "workflows" and parts[i - 1].lower() == parent_marker:
+            tail = parts[i + 1:]
+            return Path(*tail) if tail else None
+    return None
+
+
 def _repoint_legacy_rows(s, root: Path) -> int:
-    if _LEGACY_WORKFLOWS_DIR is None:
+    try:
+        root_resolved = root.resolve()
+    except OSError:
         return 0
-    legacy_root = Path(_LEGACY_WORKFLOWS_DIR).resolve()
-    moved = 0
-    for row in s.execute(select(db.Workflow)).scalars().all():
+    legacy_root = None
+    if _LEGACY_WORKFLOWS_DIR is not None:
         try:
-            rel = Path(row.file_path).resolve().relative_to(legacy_root)
-        except (ValueError, OSError):
+            legacy_root = Path(_LEGACY_WORKFLOWS_DIR).resolve()
+        except OSError:
+            legacy_root = None
+    from .link import _native_workflows_dir
+    native_root = _native_workflows_dir()
+    native_resolved = None
+    if native_root is not None:
+        try:
+            native_resolved = Path(native_root).resolve()
+        except OSError:
+            native_resolved = None
+
+    rows = s.execute(select(db.Workflow)).scalars().all()
+    taken = {r.file_path for r in rows}
+    moved = 0
+    for row in rows:
+        try:
+            rp = Path(row.file_path).resolve()
+        except (OSError, ValueError):
             continue
-        new_path = root / rel
-        if new_path.exists():
-            row.file_path = str(new_path)
-            moved += 1
+
+        link_type = getattr(row, "link_type", db.LINK_TYPE_MANAGED) or db.LINK_TYPE_MANAGED
+        if link_type == db.LINK_TYPE_NATIVE:
+            if native_resolved is None:
+                continue
+            try:
+                rp.relative_to(native_resolved)
+                continue
+            except ValueError:
+                pass
+            rel = _marker_rel(rp, "default")
+            target_root = Path(native_root)
+        else:
+            try:
+                rp.relative_to(root_resolved)
+                continue
+            except ValueError:
+                pass
+            rel = None
+            if legacy_root is not None:
+                try:
+                    rel = rp.relative_to(legacy_root)
+                except ValueError:
+                    rel = None
+            if rel is None:
+                rel = _marker_rel(rp, "comfytv")
+            target_root = root
+
+        if rel is None:
+            continue
+        new_path = target_root / rel
+        if not new_path.exists():
+            continue
+        np_str = str(new_path)
+        if np_str in taken:
+            continue
+        taken.discard(row.file_path)
+        row.file_path = np_str
+        taken.add(np_str)
+        moved += 1
     if moved:
         s.flush()
-        _log.info("[ComfyTV/workflow_db] repointed %d workflow row(s) from the "
-                  "legacy directory to %s", moved, root)
+        _log.info("[ComfyTV/workflow_db] repointed %d workflow row(s) from a "
+                  "previous workflows location to %s", moved, root)
     return moved
 
 

--- a/tests/test_workflow_db.py
+++ b/tests/test_workflow_db.py
@@ -1498,3 +1498,78 @@ class TestLegacyMigration:
         assert result["synced"] == []
         assert result["updated"] == []
         assert (user_root / "image" / "wf.json").read_text() == pre_existing
+
+    def test_user_dir_move_repoints_rows(self, reset_db, tmp_path, monkeypatch):
+        from ComfyTV import db
+        legacy, user_root = self._setup_dirs(tmp_path, monkeypatch)
+        old_user = tmp_path / "old-user" / "comfytv" / "workflows" / "image"
+        old_user.mkdir(parents=True)
+        content = json.dumps({"nodes": []})
+        (old_user / "wf.json").write_text(content)
+        (user_root / "image").mkdir(parents=True)
+        (user_root / "image" / "wf.json").write_text(content)
+
+        with db.get_session() as s:
+            row = db.Workflow(kind="image", label="wf",
+                              file_path=str(old_user / "wf.json"),
+                              is_default=True, order_=100)
+            s.add(row)
+            s.commit()
+            row_id = row.id
+
+        wdb.seed_workflows_from_disk(("image",))
+
+        rows = wdb.list_workflows_overview("image")
+        assert len(rows) == 1
+        assert rows[0]["id"] == row_id
+        assert str(user_root) in rows[0]["file_path"]
+        assert rows[0]["is_default"] is True
+
+    def test_user_dir_move_keeps_preset_label_and_id(self, reset_db, tmp_path, monkeypatch):
+        from ComfyTV import db
+        legacy, user_root = self._setup_dirs(tmp_path, monkeypatch)
+        old_user = tmp_path / "prev" / "comfytv" / "workflows" / "image"
+        old_user.mkdir(parents=True)
+        content = json.dumps({"nodes": []})
+        (old_user / "sd15.json").write_text(content)
+        (user_root / "image").mkdir(parents=True)
+        (user_root / "image" / "sd15.json").write_text(content)
+        (user_root / "image" / "sd15_preset.json").write_text(
+            json.dumps({"label": "SD 1.5"}))
+
+        with db.get_session() as s:
+            row = db.Workflow(kind="image", label="SD 1.5",
+                              file_path=str(old_user / "sd15.json"), order_=100)
+            s.add(row)
+            s.commit()
+            row_id = row.id
+
+        wdb.seed_workflows_from_disk(("image",))
+
+        rows = wdb.list_workflows_overview("image")
+        assert len(rows) == 1
+        assert rows[0]["id"] == row_id
+        assert rows[0]["label"] == "SD 1.5"
+        assert str(user_root) in rows[0]["file_path"]
+
+    def test_two_stale_rows_for_same_rel_do_not_collide(self, reset_db, tmp_path, monkeypatch):
+        from ComfyTV import db
+        legacy, user_root = self._setup_dirs(tmp_path, monkeypatch)
+        content = json.dumps({"nodes": []})
+        (legacy / "image" / "wf.json").write_text(content)
+        old_user = tmp_path / "prev" / "comfytv" / "workflows" / "image"
+        old_user.mkdir(parents=True)
+        (old_user / "wf.json").write_text(content)
+
+        with db.get_session() as s:
+            s.add(db.Workflow(kind="image", label="wf",
+                              file_path=str(legacy / "image" / "wf.json")))
+            s.add(db.Workflow(kind="image", label="wf (old)",
+                              file_path=str(old_user / "wf.json")))
+            s.commit()
+
+        wdb.seed_workflows_from_disk(("image",))
+
+        rows = wdb.list_workflows_overview("image")
+        under_new = [r for r in rows if str(user_root) in r["file_path"]]
+        assert len(under_new) == 1

--- a/tests/test_workflow_link.py
+++ b/tests/test_workflow_link.py
@@ -179,3 +179,47 @@ class TestUnlinkClearsDefault:
 
         wdb.unlink_workflow(res["id"])
         assert wdb.get_default_label("image") is None
+
+
+class TestNativeRepointOnUserDirMove:
+    def test_native_rows_follow_user_dir(self, reset_db, native_dir, tmp_path, monkeypatch):
+        from ComfyTV import db
+        (native_dir / "fav.json").write_text(GUI, encoding="utf-8")
+        old = tmp_path / "old-user" / "default" / "workflows"
+        old.mkdir(parents=True)
+        (old / "fav.json").write_text(GUI, encoding="utf-8")
+        with db.get_session() as s:
+            s.add(db.Workflow(kind="image", label="fav",
+                              file_path=str(old / "fav.json"),
+                              link_type=db.LINK_TYPE_NATIVE))
+            s.commit()
+
+        wroot = tmp_path / "wroot"
+        wroot.mkdir()
+        monkeypatch.setattr(wdb.seed, "_WORKFLOWS_DIR", wroot)
+        wdb.seed_workflows_from_disk(("image",))
+
+        rows = wdb.list_workflows_overview("image")
+        assert len(rows) == 1
+        assert str(native_dir) in rows[0]["file_path"]
+        assert rows[0]["link_type"] == db.LINK_TYPE_NATIVE
+
+    def test_native_row_untouched_when_new_copy_missing(self, reset_db, native_dir, tmp_path, monkeypatch):
+        from ComfyTV import db
+        old = tmp_path / "old-user" / "default" / "workflows"
+        old.mkdir(parents=True)
+        (old / "keep.json").write_text(GUI, encoding="utf-8")
+        with db.get_session() as s:
+            s.add(db.Workflow(kind="image", label="keep",
+                              file_path=str(old / "keep.json"),
+                              link_type=db.LINK_TYPE_NATIVE))
+            s.commit()
+
+        wroot = tmp_path / "wroot"
+        wroot.mkdir()
+        monkeypatch.setattr(wdb.seed, "_WORKFLOWS_DIR", wroot)
+        wdb.seed_workflows_from_disk(("image",))
+
+        rows = wdb.list_workflows_overview("image")
+        assert len(rows) == 1
+        assert str(old) in rows[0]["file_path"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow database migration when workflow directories move.
  * Preserved workflow labels, IDs, and default status during path updates.
  * Prevented duplicate or conflicting workflow entries during migration.
  * Native workflows now follow their new location when the corresponding file exists.
  * Existing native workflow paths remain unchanged when replacement files are unavailable.

* **Tests**
  * Added coverage for moved user workflows, preset-associated workflows, collision handling, and native workflow relocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->