### PR TITLE
fix: clear read-only attribute when pruning backup snapshots on Windows

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -3,6 +3,7 @@ import os
 import re
 import shutil
 import sqlite3
+import stat
 from datetime import datetime
 from typing import Any, Optional
 
@@ -54,6 +55,16 @@ def _copy_sqlite_db(src_db: str, dst_db: str) -> None:
         src_conn.close()
 
 
+def _rmtree_force(path: str) -> None:
+    def _onexc(func, p, _exc):
+        os.chmod(p, stat.S_IWRITE)
+        func(p)
+    try:
+        shutil.rmtree(path, onexc=_onexc)
+    except TypeError:
+        shutil.rmtree(path, onerror=_onexc)
+
+
 def prune_old_snapshots(root: str, max_count: int) -> list[str]:
     if max_count < 1 or not os.path.isdir(root):
         return []
@@ -65,7 +76,7 @@ def prune_old_snapshots(root: str, max_count: int) -> list[str]:
     for name in snapshots[:-max_count]:
         target = os.path.join(root, name)
         try:
-            shutil.rmtree(target)
+            _rmtree_force(target)
             removed.append(name)
         except OSError as e:
             logger.warning("[ComfyTV/backup] failed to prune %s: %s", target, e)
@@ -104,7 +115,10 @@ def run_backup(cfg: Optional[dict[str, Any]] = None,
             _copy_sqlite_db(src_db, os.path.join(dest, "data.db"))
     except (OSError, sqlite3.Error) as e:
         logger.warning("[ComfyTV/backup] backup failed: %s", e)
-        shutil.rmtree(os.path.join(root, name), ignore_errors=True)
+        try:
+            _rmtree_force(os.path.join(root, name))
+        except OSError:
+            pass
         return {"ok": False, "error": str(e)}
 
     prune_old_snapshots(root, int(cfg.get("db-backup-max-count") or 1))

--- a/tests/test_settings_backup.py
+++ b/tests/test_settings_backup.py
@@ -191,6 +191,19 @@ class TestBackup:
         names = sorted(p.name for p in root.iterdir())
         assert names == ["20260805-090200", "20260805-090300"]
 
+    def test_rotation_prunes_readonly_files(self, tmp_path, node_root, monkeypatch):
+        from ComfyTV import backup
+        data = _make_data_dir(tmp_path)
+        locked = data / "workflows" / "locked.json"
+        locked.write_text("{}", encoding="utf-8")
+        locked.chmod(0o444)
+        monkeypatch.setattr(backup, "data_dir", lambda: str(data))
+        root = tmp_path / "dest"
+        cfg = {"db-backup-path": str(root), "db-backup-max-count": 1}
+        for minute in (1, 2):
+            assert backup.run_backup(cfg, now=datetime(2026, 8, 5, 9, minute, 0))["ok"] is True
+        assert sorted(p.name for p in root.iterdir()) == ["20260805-090200"]
+
     def test_missing_data_dir_fails_cleanly(self, tmp_path, node_root, monkeypatch):
         from ComfyTV import backup
         monkeypatch.setattr(backup, "data_dir", lambda: str(tmp_path / "absent"))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backup cleanup and snapshot rotation now handle read-only files more reliably.
  * Failed backups can be removed successfully even when their contents are write-protected.

* **Tests**
  * Added coverage confirming backups complete and retain only the newest snapshot when source data includes read-only files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->