### PR TITLE
fix: unwired optional media bindings no longer feed loaders an empty path (#274)

### DIFF
--- a/runners/_workflow_mutate.py
+++ b/runners/_workflow_mutate.py
@@ -2,9 +2,11 @@ import logging
 
 from .base import RunnerContext
 from ._workflow_resolve import (
+    _MEDIA_KINDS,
     _UPSTREAM_BUCKET_BY_KIND,
     _UPSTREAM_PAT,
     _Resolver,
+    KEEP_ORIGINAL,
 )
 
 _log = logging.getLogger(__name__)
@@ -136,6 +138,92 @@ def _apply_prunes(workflow: dict, config: dict, ctx: RunnerContext) -> set[str]:
     return pruned
 
 
+def _input_is_required(class_type: str | None, input_name: str) -> bool:
+    import nodes as comfy_nodes
+    cls = comfy_nodes.NODE_CLASS_MAPPINGS.get(class_type)
+    if cls is None:
+        return True
+    try:
+        spec = cls.INPUT_TYPES()
+    except Exception:
+        return True
+    return input_name in (spec.get("required") or {})
+
+
+def _cascade_drop_plan(workflow: dict, config: dict, root: str) -> set[str] | None:
+    import nodes as comfy_nodes
+    hinted = str((config.get("result") or {}).get("node") or "")
+    dropped: set[str] = set()
+    stack = [root]
+    while stack:
+        nid = stack.pop()
+        if nid in dropped or nid not in workflow:
+            continue
+        node = workflow[nid]
+        cls = comfy_nodes.NODE_CLASS_MAPPINGS.get(node.get("class_type"))
+        if nid == hinted or (cls is not None and getattr(cls, "OUTPUT_NODE", False)):
+            return None
+        dropped.add(nid)
+        for cid, cnode in workflow.items():
+            if cid in dropped:
+                continue
+            for iname, v in (cnode.get("inputs") or {}).items():
+                if (isinstance(v, list) and len(v) == 2 and str(v[0]) == nid
+                        and _input_is_required(cnode.get("class_type"), iname)):
+                    stack.append(cid)
+                    break
+    return dropped
+
+
+def _auto_prune_unbound(workflow: dict, config: dict, ctx: RunnerContext) -> set[str]:
+    roots: set[str] = set()
+    for node_id, fields in (config.get("inputs") or {}).items():
+        if str(node_id) not in workflow:
+            continue
+        for _input_name, spec in (fields or {}).items():
+            m = _UPSTREAM_PAT.match(str(spec.get("from") or ""))
+            if not m or m.group(1) not in _MEDIA_KINDS:
+                continue
+            if spec.get("required") or spec.get("default") is not None:
+                continue
+            kind, idx_str = m.group(1), m.group(3)
+            idx = int(idx_str) if idx_str else 0
+            upstream = ctx.upstream.get(_UPSTREAM_BUCKET_BY_KIND[kind]) or []
+            if isinstance(upstream, str):
+                upstream = [upstream]
+            if idx < len(upstream) and upstream[idx] not in (None, ""):
+                continue
+            roots.add(str(node_id))
+            break
+
+    pruned: set[str] = set()
+    for root in sorted(roots):
+        plan = _cascade_drop_plan(workflow, config, root)
+        if plan is None:
+            _log.warning(
+                "[ComfyTV] node %s has an unwired optional media binding but "
+                "removing it would take an output node down — leaving it in "
+                "place with its own widget values", root,
+            )
+            continue
+        for nid in plan:
+            workflow.pop(nid, None)
+        pruned |= plan
+
+    if not pruned:
+        return pruned
+    for cnode in workflow.values():
+        inputs = cnode.get("inputs") or {}
+        dangling = [k for k, v in inputs.items()
+                    if isinstance(v, list) and len(v) == 2 and str(v[0]) in pruned]
+        for k in dangling:
+            inputs.pop(k)
+    pruned |= _gc_unreachable(workflow, config)
+    _log.info("[ComfyTV] auto-pruned %d node(s) fed by unwired optional "
+              "bindings: %s", len(pruned), ", ".join(sorted(pruned)))
+    return pruned
+
+
 def _apply_overrides(workflow: dict, config: dict, resolver: _Resolver,
                      pruned_nodes: set[str] | None = None) -> None:
     pruned_nodes = pruned_nodes or set()
@@ -156,7 +244,10 @@ def _apply_overrides(workflow: dict, config: dict, resolver: _Resolver,
         node_inputs = node.setdefault("inputs", {})
         for input_name, spec in (fields or {}).items():
             where = f"node {node_id} input {input_name!r}"
-            node_inputs[input_name] = resolver.resolve(where, spec)
+            value = resolver.resolve(where, spec)
+            if value is KEEP_ORIGINAL:
+                continue
+            node_inputs[input_name] = value
 
     if orphaned:
         from .notify import notify_toast

--- a/runners/_workflow_resolve.py
+++ b/runners/_workflow_resolve.py
@@ -15,6 +15,10 @@ _UPSTREAM_PAT = re.compile(
     r'^upstream_(image|video|audio|text|model):(annotated|value|masked)(?:\[(\d+)\])?$'
 )
 
+KEEP_ORIGINAL = object()
+
+_MEDIA_KINDS = ("image", "video", "audio", "model")
+
 
 _UPSTREAM_BUCKET_BY_KIND = {
     'image': 'images', 'video': 'videos', 'audio': 'audio', 'text': 'texts',
@@ -162,6 +166,7 @@ class _Resolver:
         cast = spec.get("cast")
         default = _resolve_default(spec.get("default"))
         value: Any = None
+        media_upstream = False
 
         if src == "main_prompt":
             value = (self.ctx.main_prompt or "").strip()
@@ -178,6 +183,7 @@ class _Resolver:
             value = self._length_cached()
         elif (m := _UPSTREAM_PAT.match(src)):
             kind, suffix, idx_str = m.group(1), m.group(2), m.group(3)
+            media_upstream = kind in _MEDIA_KINDS
             idx = int(idx_str) if idx_str else 0
             upstream = self.ctx.upstream.get(_UPSTREAM_BUCKET_BY_KIND[kind]) or []
             if isinstance(upstream, str):  # audio may be a single string
@@ -209,6 +215,12 @@ class _Resolver:
                 raise RuntimeError(
                     spec.get("error") or f"{where}: required but empty"
                 )
+            if media_upstream:
+                _log.info(
+                    "[ComfyTV] %s: optional %s has nothing wired — "
+                    "keeping the workflow's own value", where, src,
+                )
+                return KEEP_ORIGINAL
             value = ""
 
         prefix = spec.get("prefix")

--- a/runners/local_comfy.py
+++ b/runners/local_comfy.py
@@ -17,6 +17,7 @@ from ._workflow_mutate import (  # noqa: F401
     _apply_overrides,
     _apply_prunes,
     _auto_detect_result,
+    _auto_prune_unbound,
     _output_node_ids,
     _split_runner_id,
 )
@@ -52,6 +53,7 @@ def prepare_workflow(runner_id: str, kinds, ctx: RunnerContext) -> tuple[dict, d
     workflow = copy.deepcopy(config["api_json"])
 
     pruned_nodes = _apply_prunes(workflow, config, ctx)
+    pruned_nodes |= _auto_prune_unbound(workflow, config, ctx)
     resolver = _Resolver(config, ctx)
     _apply_overrides(workflow, config, resolver, pruned_nodes)
 

--- a/runners/workflow_db/seed.py
+++ b/runners/workflow_db/seed.py
@@ -223,6 +223,21 @@ def _read_preset(file_path: Path) -> dict:
     return data if isinstance(data, dict) else {}
 
 
+def _free_label(s, kind: str, wanted: str, exclude_id: Optional[int] = None) -> str:
+    base = wanted
+    n = 2
+    while True:
+        q = select(db.Workflow.id).where(
+            (db.Workflow.kind == kind) & (db.Workflow.label == wanted)
+        )
+        if exclude_id is not None:
+            q = q.where(db.Workflow.id != exclude_id)
+        if s.execute(q).first() is None:
+            return wanted
+        wanted = f"{base}-{n}"
+        n += 1
+
+
 def _claim_label_or_skip(s, row: db.Workflow, new_label: str) -> bool:
     existing = s.execute(
         select(db.Workflow).where(
@@ -317,7 +332,7 @@ def _upsert_workflow_row(s, kind: str, file_path: Path) -> tuple[db.Workflow, bo
     if row is None:
         row = db.Workflow(
             kind=kind,
-            label=_label_from_stem(file_path.stem),
+            label=_free_label(s, kind, _label_from_stem(file_path.stem)),
             file_path=str(file_path),
             order_=100,
         )
@@ -373,7 +388,7 @@ def reset_workflow_to_preset(workflow_id: int) -> Optional[dict]:
             db.WorkflowInputBinding.__table__.delete()
                 .where(db.WorkflowInputBinding.workflow_id == row.id)
         )
-        row.label = _label_from_stem(file_path.stem)
+        row.label = _free_label(s, row.kind, _label_from_stem(file_path.stem), row.id)
         row.order_ = 100
         row.description = None
         row.result_type = None
@@ -424,7 +439,7 @@ def import_workflow(kind: str, filename: str, content: str) -> dict:
     with db.get_session() as s:
         row, _ = _upsert_workflow_row(s, kind, path)
         if original_label:
-            row.label = original_label
+            row.label = _free_label(s, kind, original_label, row.id)
         label = row.label
         s.commit()
 

--- a/tests/test_local_comfy.py
+++ b/tests/test_local_comfy.py
@@ -719,6 +719,136 @@ class TestApplyPrunes:
         assert set(wf) == {"gen"}
 
 
+# ─── _auto_prune_unbound ─────────────────────────────────────────────────────
+
+def _stub_class(required=(), output=False):
+    req = tuple(required)
+
+    class C:
+        OUTPUT_NODE = output
+
+        @classmethod
+        def INPUT_TYPES(cls):
+            return {"required": {k: ("X",) for k in req}, "optional": {}}
+
+    return C
+
+
+class TestAutoPruneUnbound:
+    def _ctx(self, **kw):
+        defaults = dict(
+            kind="video", main_prompt="x",
+            upstream={"images": [], "videos": [], "audio": [], "texts": []},
+            options={},
+        )
+        defaults.update(kw)
+        return RunnerContext(**defaults)
+
+    def _register(self, comfy_nodes):
+        comfy_nodes.NODE_CLASS_MAPPINGS.update({
+            "LoadVideo": _stub_class(required=("file",)),
+            "GetVideoComponents": _stub_class(required=("video",)),
+            "MiniMaxH3ReferenceToVideo": _stub_class(required=("prompt",)),
+            "SaveVideo": _stub_class(required=("video",), output=True),
+            "LoadImage": _stub_class(required=("image",)),
+            "SaveImage": _stub_class(required=("images",), output=True),
+        })
+
+    def _h3_video_workflow(self):
+        return {
+            "301": {"class_type": "LoadVideo", "inputs": {"file": "sample.mp4"}},
+            "302": {"class_type": "GetVideoComponents",
+                    "inputs": {"video": ["301", 0]}},
+            "h3": {"class_type": "MiniMaxH3ReferenceToVideo", "inputs": {
+                "prompt": "x",
+                "ref_videos.ref_video_0": ["302", 0],
+                "ref_video_audios.ref_video_audio_0": ["302", 1],
+            }},
+            "save": {"class_type": "SaveVideo", "inputs": {"video": ["h3", 0]}},
+        }
+
+    def test_unwired_optional_video_drops_loader_chain(self, comfy_nodes):
+        self._register(comfy_nodes)
+        wf = self._h3_video_workflow()
+        cfg = {"inputs": {"301": {"file": {"from": "upstream_video:annotated[0]"}}}}
+        pruned = lc._auto_prune_unbound(wf, cfg, self._ctx())
+        assert pruned == {"301", "302"}
+        assert set(wf) == {"h3", "save"}
+        assert wf["h3"]["inputs"] == {"prompt": "x"}
+
+    def test_wired_upstream_left_alone(self, comfy_nodes):
+        self._register(comfy_nodes)
+        wf = self._h3_video_workflow()
+        cfg = {"inputs": {"301": {"file": {"from": "upstream_video:annotated[0]"}}}}
+        ctx = self._ctx(upstream={
+            "images": [], "videos": ["/view?filename=a.mp4"],
+            "audio": [], "texts": [],
+        })
+        pruned = lc._auto_prune_unbound(wf, cfg, ctx)
+        assert pruned == set()
+        assert set(wf) == {"301", "302", "h3", "save"}
+
+    def test_required_binding_not_pruned(self, comfy_nodes):
+        self._register(comfy_nodes)
+        wf = self._h3_video_workflow()
+        cfg = {"inputs": {"301": {"file": {
+            "from": "upstream_video:annotated[0]", "required": True,
+        }}}}
+        assert lc._auto_prune_unbound(wf, cfg, self._ctx()) == set()
+        assert "301" in wf
+
+    def test_binding_with_default_not_pruned(self, comfy_nodes):
+        self._register(comfy_nodes)
+        wf = self._h3_video_workflow()
+        cfg = {"inputs": {"301": {"file": {
+            "from": "upstream_video:annotated[0]", "default": "fallback.mp4",
+        }}}}
+        assert lc._auto_prune_unbound(wf, cfg, self._ctx()) == set()
+        assert "301" in wf
+
+    def test_text_upstream_not_pruned(self, comfy_nodes):
+        self._register(comfy_nodes)
+        wf = {"7": {"class_type": "LoadVideo", "inputs": {"file": "t"}}}
+        cfg = {"inputs": {"7": {"file": {"from": "upstream_text:value[0]"}}}}
+        assert lc._auto_prune_unbound(wf, cfg, self._ctx()) == set()
+
+    def test_cascade_reaching_output_node_aborts(self, comfy_nodes):
+        self._register(comfy_nodes)
+        wf = {
+            "load": {"class_type": "LoadImage", "inputs": {"image": "x.png"}},
+            "save": {"class_type": "SaveImage", "inputs": {"images": ["load", 0]}},
+        }
+        cfg = {"inputs": {"load": {"image": {"from": "upstream_image:annotated[0]"}}}}
+        assert lc._auto_prune_unbound(wf, cfg, self._ctx()) == set()
+        assert set(wf) == {"load", "save"}
+
+    def test_unknown_consumer_class_treated_as_required(self, comfy_nodes):
+        self._register(comfy_nodes)
+        wf = {
+            "load": {"class_type": "LoadVideo", "inputs": {"file": "x.mp4"}},
+            "mystery": {"class_type": "SomeCustomThing",
+                        "inputs": {"video": ["load", 0]}},
+            "h3": {"class_type": "MiniMaxH3ReferenceToVideo", "inputs": {
+                "prompt": "x", "ref_videos.ref_video_0": ["mystery", 0],
+            }},
+            "save": {"class_type": "SaveVideo", "inputs": {"video": ["h3", 0]}},
+        }
+        cfg = {"inputs": {"load": {"file": {"from": "upstream_video:annotated[0]"}}}}
+        pruned = lc._auto_prune_unbound(wf, cfg, self._ctx())
+        assert pruned == {"load", "mystery"}
+        assert wf["h3"]["inputs"] == {"prompt": "x"}
+
+    def test_gc_sweeps_orphaned_feeders_of_dropped_nodes(self, comfy_nodes):
+        self._register(comfy_nodes)
+        wf = self._h3_video_workflow()
+        wf["upscaler"] = {"class_type": "SomeUpscaler", "inputs": {}}
+        wf["301"]["inputs"]["model"] = ["upscaler", 0]
+        cfg = {"inputs": {"301": {"file": {"from": "upstream_video:annotated[0]"}}}}
+        pruned = lc._auto_prune_unbound(wf, cfg, self._ctx())
+        assert pruned == {"301", "302", "upscaler"}
+        assert set(wf) == {"h3", "save"}
+
+
 # ─── _apply_overrides ────────────────────────────────────────────────────────
 
 class TestApplyOverrides:
@@ -765,6 +895,44 @@ class TestApplyOverrides:
         resolver = lc._Resolver(cfg, self._ctx())
         lc._apply_overrides(wf, cfg, resolver)
         assert wf["3"]["inputs"]["x"] == "abc"
+
+    def test_unwired_optional_media_keeps_widget_value(self):
+        wf = {"301": {"class_type": "LoadVideo",
+                      "inputs": {"file": "sample.mp4"}}}
+        cfg = {"inputs": {"301": {"file": {"from": "upstream_video:annotated[0]"}}}}
+        resolver = lc._Resolver(cfg, self._ctx())
+        lc._apply_overrides(wf, cfg, resolver)
+        assert wf["301"]["inputs"]["file"] == "sample.mp4"
+
+    def test_unwired_optional_text_still_writes_empty(self):
+        wf = {"5": {"class_type": "CLIPTextEncode",
+                    "inputs": {"text": "template prompt"}}}
+        cfg = {"inputs": {"5": {"text": {"from": "upstream_text:value[0]"}}}}
+        resolver = lc._Resolver(cfg, self._ctx())
+        lc._apply_overrides(wf, cfg, resolver)
+        assert wf["5"]["inputs"]["text"] == ""
+
+    def test_unwired_required_media_still_raises(self):
+        wf = {"301": {"class_type": "LoadVideo",
+                      "inputs": {"file": "sample.mp4"}}}
+        cfg = {"inputs": {"301": {"file": {
+            "from": "upstream_video:annotated[0]", "required": True,
+        }}}}
+        resolver = lc._Resolver(cfg, self._ctx())
+        with pytest.raises(RuntimeError, match="required but empty"):
+            lc._apply_overrides(wf, cfg, resolver)
+
+    def test_wired_optional_media_overrides_widget_value(self):
+        wf = {"301": {"class_type": "LoadVideo",
+                      "inputs": {"file": "sample.mp4"}}}
+        cfg = {"inputs": {"301": {"file": {"from": "upstream_video:annotated[0]"}}}}
+        ctx = self._ctx(upstream={
+            "images": [], "videos": ["/view?filename=real.mp4"],
+            "audio": [], "texts": [],
+        })
+        resolver = lc._Resolver(cfg, ctx)
+        lc._apply_overrides(wf, cfg, resolver)
+        assert wf["301"]["inputs"]["file"] == "real.mp4 [output]"
 
 
 # ─── _view_url + _save_files_from ────────────────────────────────────────────

--- a/tests/test_workflow_db.py
+++ b/tests/test_workflow_db.py
@@ -488,6 +488,64 @@ class TestSeedAndCRUD:
         refresh_registry()
         assert "Flux Fill Inpaint33" in RUNNER_REGISTRY.labels_for_kind("inpaint")
 
+    def test_seed_new_row_survives_stem_label_collision(
+            self, reset_db, tmp_path, monkeypatch):
+        from pathlib import Path
+        wdir = tmp_path / "workflows"
+        self._make_workflow(wdir, "first", "image", preset={"label": "second"})
+        self._make_workflow(wdir, "second", "image")
+        monkeypatch.setattr(wdb.seed, "_WORKFLOWS_DIR", Path(wdir))
+        wdb.seed_workflows_from_disk(("image",))
+        labels = {r["label"] for r in wdb.list_workflows() if r["kind"] == "image"}
+        assert labels == {"second", "second-2"}
+
+    def test_import_survives_label_collision(self, reset_db, tmp_path, monkeypatch):
+        from pathlib import Path
+        wdir = tmp_path / "workflows"
+        self._make_workflow(wdir, "fancy", "image", preset={"label": "Nice"})
+        monkeypatch.setattr(wdb.seed, "_WORKFLOWS_DIR", Path(wdir))
+        wdb.seed_workflows_from_disk(("image",))
+
+        res = wdb.import_workflow("image", "Nice.json",
+                                  json.dumps({"nodes": [{"id": 1}]}))
+        assert res["label"] == "Nice-2"
+
+    def test_reimport_same_file_keeps_own_label(self, reset_db, tmp_path, monkeypatch):
+        from pathlib import Path
+        wdir = tmp_path / "workflows"
+        wdir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(wdb.seed, "_WORKFLOWS_DIR", Path(wdir))
+        gui = json.dumps({"nodes": [{"id": 1}]})
+        first = wdb.import_workflow("image", "mine.json", gui)
+        again = wdb.import_workflow("image", "mine.json", gui)
+        assert first["label"] == again["label"] == "mine"
+
+    def test_reset_survives_stem_label_collision(
+            self, reset_db, tmp_path, monkeypatch):
+        from pathlib import Path
+        from ComfyTV import db as cdb
+        wdir = tmp_path / "workflows"
+        self._make_workflow(wdir, "sage", "video", preset={"order": 5})
+        self._make_workflow(wdir, "other", "video")
+        monkeypatch.setattr(wdb.seed, "_WORKFLOWS_DIR", Path(wdir))
+        wdb.seed_workflows_from_disk(("video",))
+
+        from sqlalchemy import select
+        with cdb.get_session() as s:
+            sage = s.execute(select(cdb.Workflow).where(
+                cdb.Workflow.label == "sage")).scalar_one()
+            other = s.execute(select(cdb.Workflow).where(
+                cdb.Workflow.label == "other")).scalar_one()
+            sage_id = sage.id
+            sage.label = "my custom name"
+            s.flush()
+            other.label = "sage"
+            s.commit()
+
+        result = wdb.reset_workflow_to_preset(sage_id)
+        assert result is not None and result["ok"]
+        assert result["label"] == "sage-2"
+
     def test_safe_stem(self):
         assert wdb._safe_stem("My Cool Upload.json") == "My-Cool-Upload"
         assert wdb._safe_stem("../../etc/passwd") == "passwd"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically removes unused optional media inputs and related orphaned workflow nodes while preserving output nodes.
  * Preserves existing values when optional media inputs are unwired instead of replacing them with empty values.
  * Maintains appropriate handling for required inputs, defaults, and wired media connections.
  * Prevents duplicate workflow labels by adding numeric suffixes during creation, import, and reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->