### PR TITLE
docs: catch the MCP guide up with the Previz retirement

### DIFF
--- a/docs-site/guides/mcp.mdx
+++ b/docs-site/guides/mcp.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent access (MCP)"
-description: "ComfyTV ships an MCP server so AI agents can read and drive your canvas: build node graphs, run stages, wait for renders, inspect results with real vision, and manage your workflow configuration — all through 39 tools."
+description: "ComfyTV ships an MCP server so AI agents can read and drive your canvas: build node graphs, run stages, wait for renders, inspect results with real vision, and manage your workflow configuration — all through 35 tools."
 ---
 
 ## What it is
@@ -72,7 +72,7 @@ Any other MCP client: point it at the same URL with the streamable HTTP transpor
 
 | Tool | What it does |
 |---|---|
-| `scene_get/edit/capture/record` | Drive a Scene 3D stage: characters, lights, cameras, animation clips |
+| `scene_get/edit/capture/record` | Drive a Scene 3D stage: characters, lights, cameras, animation clips, camera paths and the multi-shot director timeline (add_shot/patch_shot/set_path) |
 | `director_get/director_edit` | Read and edit the Director clip timeline |
 
 ## Patterns that matter

--- a/docs-site/zh/guides/bot.mdx
+++ b/docs-site/zh/guides/bot.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ComfyTV Bot"
 description: "内嵌在侧边栏的聊天代理,直接驱动你的画布:说出想要什么,它就搭节点、跑工作流、等渲染、亲眼看结果、继续迭代 — 由你本机已装的 agent CLI 驱动,任何地方都不存 API key。"
-translationSourceHash: "ea7752ef875482f1"
+translationSourceHash: "8062d4922e44dd46"
 ---
 
 ## 是什么

--- a/docs-site/zh/guides/compose.mdx
+++ b/docs-site/zh/guides/compose.mdx
@@ -1,6 +1,6 @@
 ---
 title: "拼接 & 编排"
-translationSourceHash: "07c5ad6662fa8cdf"
+translationSourceHash: "7c52e99f6656d658"
 ---
 
 ## 挑选器（Pickers）

--- a/docs-site/zh/guides/custom-workflows.mdx
+++ b/docs-site/zh/guides/custom-workflows.mdx
@@ -1,6 +1,6 @@
 ---
 title: "自定义工作流"
-translationSourceHash: "d2dbf64073aec335"
+translationSourceHash: "a019d3ee71210859"
 ---
 
 ComfyTV 每个 stage 的 **workflow** 下拉框，背后都是一个普通的 ComfyUI 工作流（GUI 格式）。接入自己的工作流有三条路——都**不用改 Python 代码**。

--- a/docs-site/zh/guides/mcp.mdx
+++ b/docs-site/zh/guides/mcp.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Agent 接入(MCP)"
-description: "ComfyTV 内置 MCP 服务,让 AI agent 读取并驱动你的画布:搭建节点图、跑渲染、阻塞等待、用真视觉检查结果、管理工作流配置 — 共 39 个工具。"
-translationSourceHash: "71cf6da6a58e8658"
+description: "ComfyTV 内置 MCP 服务,让 AI agent 读取并驱动你的画布:搭建节点图、跑渲染、阻塞等待、用真视觉检查结果、管理工作流配置 — 共 35 个工具。"
+translationSourceHash: "d9c7b5ba1e3affdd"
 ---
 
 ## 是什么
@@ -73,7 +73,7 @@ claude mcp add --transport http comfytv http://127.0.0.1:8188/comfytv/mcp
 
 | 工具 | 作用 |
 |---|---|
-| `scene_get/edit/capture/record` | 驱动 Scene 3D:角色、灯光、相机、动画 clip |
+| `scene_get/edit/capture/record` | 驱动 Scene 3D:角色、灯光、相机、动画 clip、相机路径与多镜导演时间轴(add_shot/patch_shot/set_path) |
 | `director_get/director_edit` | 读写导演台 clip 时间线 |
 
 ## 关键套路

--- a/docs-site/zh/guides/video-and-audio.mdx
+++ b/docs-site/zh/guides/video-and-audio.mdx
@@ -1,7 +1,7 @@
 ---
 title: "视频和音频"
 description: "视频**生成**在 Generate 分组里（见 [generate.zh.md](generate.zh.md)）。本页带你逛一遍**视频与音频全家桶**——约 100 个视频节点和 30+ 个音频节点。以下所有能力都直接作用在素材本身，不需要下载任何 AI 模型；许多节点在浏览器里就有实时预览。每个节点的参数详解见 [comfytv.org](https://comfytv.org) 的**节点参考**。"
-translationSourceHash: "2a1f92284a73d2b4"
+translationSourceHash: "80ea37591f015ae4"
 ---
 
 ![视频编辑 stage](/images/video-tools.png)

--- a/docs-site/zh/node-reference/audio-clip.mdx
+++ b/docs-site/zh/node-reference/audio-clip.mdx
@@ -2,7 +2,7 @@
 title: "音频剪辑"
 description: "在波形时间线上把音频裁到 [start_s, end_s]。接受音频或视频输入,输出单条裁剪后的音频快照。"
 sidebarTitle: "音频剪辑"
-translationSourceHash: "ab3ed5734e0ff56f"
+translationSourceHash: "6e2dc0e6022a34e0"
 ---
 
 <Frame caption="音频剪辑 · 截图待补">

--- a/docs-site/zh/node-reference/audio-split.mdx
+++ b/docs-site/zh/node-reference/audio-split.mdx
@@ -2,7 +2,7 @@
 title: "音频分割"
 description: "在波形上的一个点把音频切成两段,两半分别输出。"
 sidebarTitle: "音频分割"
-translationSourceHash: "d08b3c61fb13a1ae"
+translationSourceHash: "9550b2fef17fb726"
 ---
 
 <Frame caption="音频分割 · 截图待补">

--- a/docs-site/zh/node-reference/director.mdx
+++ b/docs-site/zh/node-reference/director.mdx
@@ -2,7 +2,7 @@
 title: "导演台"
 description: "一条 clip 时间线渲染整部短片:逐段 prompt、参考、转场、seed,内容寻址缓存让改动过的段落才重渲。"
 sidebarTitle: "导演台"
-translationSourceHash: "a5c3992ae52c01ac"
+translationSourceHash: "dd573c65a52be209"
 ---
 
 <Frame caption="导演台 · 截图待补">

--- a/docs-site/zh/node-reference/shot-images.mdx
+++ b/docs-site/zh/node-reference/shot-images.mdx
@@ -2,7 +2,7 @@
 title: "分镜图集"
 description: "根据 **Storyboard** 分镜表，为每一镜自动跑图像 workflow 出图——把「文字分镜」变成「可视分镜图集」的批量生成节点。"
 sidebarTitle: "分镜图集"
-translationSourceHash: "fbbecc97b1a318c6"
+translationSourceHash: "b7de04862ddb0494"
 ---
 
 <Frame caption="分镜图集 · 截图待补">

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -2,7 +2,7 @@
 
 # Agent access (MCP)
 
-> ComfyTV ships an MCP server so AI agents can read and drive your canvas: build node graphs, run stages, wait for renders, inspect results with real vision, and manage your workflow configuration — all through 39 tools.
+> ComfyTV ships an MCP server so AI agents can read and drive your canvas: build node graphs, run stages, wait for renders, inspect results with real vision, and manage your workflow configuration — all through 35 tools.
 
 ## What it is
 
@@ -73,7 +73,7 @@ Any other MCP client: point it at the same URL with the streamable HTTP transpor
 
 | Tool | What it does |
 |---|---|
-| `scene_get/edit/capture/record` | Drive a Scene 3D stage: characters, lights, cameras, animation clips |
+| `scene_get/edit/capture/record` | Drive a Scene 3D stage: characters, lights, cameras, animation clips, camera paths and the multi-shot director timeline (add_shot/patch_shot/set_path) |
 | `director_get/director_edit` | Read and edit the Director clip timeline |
 
 ## Patterns that matter

--- a/docs/mcp.zh.md
+++ b/docs/mcp.zh.md
@@ -2,7 +2,7 @@
 
 # Agent 接入(MCP)
 
-> ComfyTV 内置 MCP 服务,让 AI agent 读取并驱动你的画布:搭建节点图、跑渲染、阻塞等待、用真视觉检查结果、管理工作流配置 — 共 39 个工具。
+> ComfyTV 内置 MCP 服务,让 AI agent 读取并驱动你的画布:搭建节点图、跑渲染、阻塞等待、用真视觉检查结果、管理工作流配置 — 共 35 个工具。
 
 ## 是什么
 
@@ -73,7 +73,7 @@ claude mcp add --transport http comfytv http://127.0.0.1:8188/comfytv/mcp
 
 | 工具 | 作用 |
 |---|---|
-| `scene_get/edit/capture/record` | 驱动 Scene 3D:角色、灯光、相机、动画 clip |
+| `scene_get/edit/capture/record` | 驱动 Scene 3D:角色、灯光、相机、动画 clip、相机路径与多镜导演时间轴(add_shot/patch_shot/set_path) |
 | `director_get/director_edit` | 读写导演台 clip 时间线 |
 
 ## 关键套路


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated MCP documentation to reflect 35 available tools.
  - Expanded Scene 3D guidance with camera path support and multi-shot director timeline controls.
  - Synchronized English and Chinese MCP documentation.
  - Refreshed translation metadata across Chinese guides and node reference pages to keep localized documentation aligned with source content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->