### PR TITLE
ComfyTV Bot Codex通用接口

### DIFF
--- a/api/mcp.py
+++ b/api/mcp.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import time
+import uuid
+from urllib.parse import unquote
 
 from aiohttp import web
 from server import PromptServer
@@ -15,6 +17,17 @@ _BROADCAST_THROTTLE_S = 60.0
 
 _last_activity: float | None = None
 _last_broadcast = 0.0
+
+# ComfyTV's handlers are stateless, but streamable-HTTP MCP clients (Codex
+# included) expect the server to manage sessions. We hand back a session id so
+# clients treat the endpoint as a sessionful streamable-HTTP server.
+_sessions: set[str] = set()
+
+
+def _new_session_id() -> str:
+    sid = uuid.uuid4().hex
+    _sessions.add(sid)
+    return sid
 
 
 def _mark_activity() -> None:
@@ -129,6 +142,100 @@ async def _tools_call(params: dict) -> dict | None:
                 "isError": True}
 
 
+def _resource_help() -> dict:
+    catalog = {
+        name: {
+            "description": spec["description"],
+            "inputSchema": spec["inputSchema"],
+        }
+        for name, spec in TOOLS.items()
+    }
+    return {"contents": [{
+        "uri": "comfytv://help",
+        "mimeType": "application/json",
+        "text": json.dumps(catalog, ensure_ascii=False),
+    }]}
+
+
+def _resource_list() -> dict:
+    resources = [{
+        "uri": "comfytv://help",
+        "name": "help",
+        "description": "Full ComfyTV tool catalog: names, descriptions and input schemas.",
+        "mimeType": "application/json",
+    }]
+    for name, spec in TOOLS.items():
+        resources.append({
+            "uri": f"comfytv://tool/{name}",
+            "name": name,
+            "description": spec["description"],
+            "mimeType": "application/json",
+        })
+    return {"resources": resources}
+
+
+def _resource_templates() -> dict:
+    return {"resourceTemplates": [{
+        "uriTemplate": "comfytv://call/{name}",
+        "name": "comfytv-tool-call",
+        "description": (
+            "Call a ComfyTV tool. Replace {name} with the tool name. Append "
+            "?<url-encoded-json-arguments> to pass arguments."
+        ),
+        "mimeType": "application/json",
+    }]}
+
+
+async def _resource_read(params: dict) -> dict:
+    uri = str(params.get("uri") or "")
+
+    if uri == "comfytv://help":
+        return _resource_help()
+
+    if uri.startswith("comfytv://tool/"):
+        name = uri[len("comfytv://tool/"):]
+        spec = TOOLS.get(name)
+        if spec is None:
+            raise ValueError(f"unknown tool {name!r}")
+        text = json.dumps({
+            "name": name,
+            "description": spec["description"],
+            "inputSchema": spec["inputSchema"],
+        }, ensure_ascii=False)
+        return {"contents": [{
+            "uri": uri, "mimeType": "application/json", "text": text,
+        }]}
+
+    if uri.startswith("comfytv://call/"):
+        rest = uri[len("comfytv://call/"):]
+        name = rest
+        args: dict = {}
+        if "?" in rest:
+            name, query = rest.split("?", 1)
+            if query:
+                args = json.loads(unquote(query))
+        spec = TOOLS.get(name)
+        if spec is None:
+            raise ValueError(f"unknown tool {name!r}")
+        try:
+            payload = await spec["handler"](args)
+        except (ValueError, TypeError, KeyError) as e:
+            payload = {"error": f"{type(e).__name__}: {e}"}
+        except Exception as e:
+            _log.exception("[ComfyTV/mcp] resource tool %s failed", name)
+            payload = {"error": f"{type(e).__name__}: {e}"}
+        if isinstance(payload, dict):
+            images = payload.pop("_images", None)
+            if images:
+                payload["_images_count"] = len(images)
+        text = json.dumps(payload, ensure_ascii=False, default=str)
+        return {"contents": [{
+            "uri": uri, "mimeType": "application/json", "text": text,
+        }]}
+
+    raise ValueError(f"unknown resource {uri!r}")
+
+
 async def _dispatch(msg: dict) -> dict | None:
     method = msg.get("method")
     msg_id = msg.get("id")
@@ -148,6 +255,17 @@ async def _dispatch(msg: dict) -> dict | None:
         if outcome is None:
             return _error(msg_id, -32602, f"unknown tool {params.get('name')!r}")
         return _result(msg_id, outcome)
+    if method == "resources/list":
+        return _result(msg_id, _resource_list())
+    if method == "resources/templates/list":
+        return _result(msg_id, _resource_templates())
+    if method == "resources/read":
+        try:
+            return _result(msg_id, await _resource_read(params))
+        except (ValueError, TypeError, KeyError) as e:
+            return _error(msg_id, -32602, str(e))
+    if method == "prompts/list":
+        return _result(msg_id, {"prompts": []})
     return _error(msg_id, -32601, f"method not found: {method}")
 
 
@@ -193,7 +311,10 @@ async def mcp_post(request: web.Request) -> web.Response:
     response = await _dispatch(msg)
     if response is None:
         return web.Response(status=202)
-    return web.json_response(response)
+    http_response = web.json_response(response)
+    if msg.get("method") == "initialize" and "result" in response:
+        http_response.headers["Mcp-Session-Id"] = _new_session_id()
+    return http_response
 
 
 @routes.get("/comfytv/mcp")
@@ -205,7 +326,8 @@ async def mcp_get(_request: web.Request) -> web.Response:
 
 
 @routes.delete("/comfytv/mcp")
-async def mcp_delete(_request: web.Request) -> web.Response:
-    return web.json_response(
-        {"error": "stateless server; there is no session to delete"}, status=405,
-    )
+async def mcp_delete(request: web.Request) -> web.Response:
+    session_id = request.headers.get("Mcp-Session-Id")
+    if session_id:
+        _sessions.discard(session_id)
+    return web.Response(status=200)

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -11,5 +11,7 @@ from .providers import (  # noqa: F401
     register_provider,
 )
 from .claude_code import ClaudeCodeProvider  # noqa: F401
+from .codex import CodexCodeProvider  # noqa: F401
 
+register_provider(CodexCodeProvider())
 register_provider(ClaudeCodeProvider())

--- a/bot/codex.py
+++ b/bot/codex.py
@@ -1,0 +1,483 @@
+import asyncio
+import base64
+import json
+import logging
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+from .providers import (
+    AgentProvider,
+    BotEvent,
+    EmitFn,
+    ProviderCaps,
+    ProviderStatus,
+    TurnHandle,
+    TurnRequest,
+    TurnResult,
+)
+
+_log = logging.getLogger(__name__)
+
+_STREAM_LIMIT = 10 * 1024 * 1024
+_TURN_TIMEOUT_S = 1800
+_TOOL_RESULT_CAP = 4000
+_PROBE_CACHE_S = 60
+_MCP_TOOL_TIMEOUT_MS = 180_000
+
+_MEDIA_EXT = {
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/gif": ".gif",
+}
+
+
+def spawn_env() -> dict:
+    env = dict(os.environ)
+    env.setdefault("MCP_TOOL_TIMEOUT", str(_MCP_TOOL_TIMEOUT_MS))
+    return env
+
+
+def resolve_codex_command() -> Optional[list[str]]:
+    """Locate the Codex CLI, mirroring how the Claude provider finds ``claude``."""
+    if sys.platform == "win32":
+        exe = shutil.which("codex.exe")
+        if exe:
+            return [exe]
+    found = shutil.which("codex")
+    if found:
+        return [found]
+
+    # Known install locations, including the bundled CLI inside the desktop app.
+    candidates = [
+        "/Applications/ChatGPT.app/Contents/Resources/codex",
+        str(Path.home() / ".local" / "bin" / "codex"),
+        str(Path.home() / ".codex" / "bin" / "codex"),
+    ]
+    for candidate in candidates:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return [candidate]
+
+    if sys.platform == "win32":
+        for candidate in candidates:
+            if os.path.isfile(candidate + ".exe"):
+                return [candidate + ".exe"]
+    return None
+
+
+def _mcp_result_text(content) -> str:
+    """Flatten MCP ``content`` blocks into a single text string."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text" or "text" in block:
+                    parts.append(str(block.get("text") or ""))
+                else:
+                    parts.append(json.dumps(block, ensure_ascii=False))
+            elif isinstance(block, str):
+                parts.append(block)
+            else:
+                parts.append(json.dumps(block, ensure_ascii=False))
+        return "\n".join(parts)
+    return json.dumps(content, ensure_ascii=False)
+
+
+class _StreamParser:
+    """Parse Codex ``codex exec --json`` JSONL into ComfyTV BotEvents."""
+
+    def __init__(self) -> None:
+        self.session_id: Optional[str] = None
+        self.result_error: str = ""
+        self.result_seen = False
+        self._text_emitted: dict[str, int] = {}
+        self._tool_names: dict[str, str] = {}
+        self._emitted_tool_use: set[str] = set()
+
+    def parse_line(self, line: str) -> list[BotEvent]:
+        line = line.strip()
+        if not line:
+            return []
+        try:
+            data = json.loads(line)
+        except ValueError:
+            return []
+        if not isinstance(data, dict):
+            return []
+
+        event_type = data.get("type")
+        if event_type == "thread.started":
+            self.session_id = str(data.get("thread_id") or self.session_id or "")
+            return []
+        if event_type == "turn.completed":
+            self.result_seen = True
+            return []
+        if event_type == "turn.failed":
+            self.result_seen = True
+            err = (data.get("error") or {}).get("message") or "turn failed"
+            self.result_error = str(err)
+            return []
+        if event_type == "error":
+            self.result_error = str(data.get("message") or "error")
+            return []
+        if event_type in ("item.started", "item.updated", "item.completed"):
+            return self._parse_item(data.get("item") or {}, event_type)
+        return []
+
+    def _parse_item(self, item: dict, event_type: str) -> list[BotEvent]:
+        item_type = item.get("type")
+        item_id = str(item.get("id") or "")
+
+        if item_type == "agent_message":
+            text = str(item.get("text") or "")
+            emitted = self._text_emitted.get(item_id, 0)
+            delta = text[emitted:] if len(text) >= emitted else text
+            self._text_emitted[item_id] = len(text)
+            return [BotEvent(t="delta", text=delta)] if delta else []
+
+        if item_type == "mcp_tool_call":
+            name = str(item.get("tool") or "")
+            arguments = item.get("arguments") or {}
+            status = item.get("status")
+
+            # A tool call is surfaced once when we first observe it (normally on
+            # item.started), and its result is surfaced when it reaches a terminal
+            # state (item.completed / item.updated with a result or error).
+            is_terminal = status in ("completed", "failed") or bool(
+                item.get("result") or item.get("error"))
+            if not is_terminal:
+                if item_id and item_id in self._emitted_tool_use:
+                    return []
+                if item_id:
+                    self._emitted_tool_use.add(item_id)
+                    self._tool_names[item_id] = name
+                if not isinstance(arguments, dict):
+                    arguments = {}
+                return [BotEvent(t="tool_use", name=name, input=arguments)]
+
+            if item.get("error") or status == "failed":
+                message = (item.get("error") or {}).get("message") or "tool failed"
+                return [BotEvent(
+                    t="tool_result",
+                    name=name or self._tool_names.get(item_id, ""),
+                    text=str(message)[:_TOOL_RESULT_CAP],
+                )]
+
+            result = item.get("result") or {}
+            text = _mcp_result_text(result.get("content"))
+            if not text and result.get("structured_content") is not None:
+                text = json.dumps(result["structured_content"], ensure_ascii=False)
+            return [BotEvent(
+                t="tool_result",
+                name=name or self._tool_names.get(item_id, ""),
+                text=text[:_TOOL_RESULT_CAP],
+            )]
+
+        return []
+
+
+class CodexCodeProvider(AgentProvider):
+    id = "codex"
+    label = "Codex"
+
+    def __init__(self, *, home_dir: Optional[str] = None) -> None:
+        self._home_dir = home_dir
+        self._probe_cache: Optional[tuple[float, ProviderStatus]] = None
+
+    def capabilities(self) -> ProviderCaps:
+        return ProviderCaps(stateful=True, tools="mcp")
+
+    def _resolve_home(self) -> str:
+        if self._home_dir:
+            os.makedirs(self._home_dir, exist_ok=True)
+            home = self._home_dir
+        else:
+            try:
+                import folder_paths
+                user = folder_paths.get_user_directory()
+            except Exception:
+                user = os.path.expanduser("~")
+            home = os.path.join(user, "comfytv", "bot-home")
+            os.makedirs(home, exist_ok=True)
+            self._home_dir = home
+        self._ensure_bot_instructions(home)
+        return home
+
+    def _ensure_bot_instructions(self, home: str) -> None:
+        """Write an AGENTS.md so Codex always has the ComfyTV tool guidance."""
+        path = os.path.join(home, "AGENTS.md")
+        content = (
+            "# ComfyTV Bot (Codex provider)\n\n"
+            "You are the ComfyTV canvas bot. In this Codex session ComfyTV is "
+            "exposed through MCP RESOURCES, not callable tools. Drive the "
+            "canvas with read_mcp_resource against the `comfytv` server:\n\n"
+            "- Read `comfytv://help` to get the full tool catalog (names, "
+            "descriptions, input schemas).\n"
+            "- Read `comfytv://tool/<name>` to see one tool's schema.\n"
+            "- Read `comfytv://call/<name>` to call a tool with no arguments.\n"
+            "- Read `comfytv://call/<name>?<url-encoded-json-object>` to call "
+            "a tool with arguments.\n\n"
+            "Example: read_mcp_resource(server=\"comfytv\", "
+            "uri=\"comfytv://call/server_info\") returns the ComfyTV version "
+            "and project count. Common tools: server_info, projects, "
+            "get_canvas, outputs, add_stage, set_stage, connect_stages, "
+            "run_stage, wait_stage, view_image.\n\n"
+            "Do not use shell, file, or web tools. Canvas writes require an "
+            "open ComfyTV browser tab; if a write fails with a tab/timeout "
+            "error, report it clearly instead of retrying endlessly.\n"
+        )
+        try:
+            existing = ""
+            if os.path.exists(path):
+                with open(path, encoding="utf-8") as fh:
+                    existing = fh.read()
+            if existing != content:
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write(content)
+        except OSError:
+            _log.warning("[ComfyTV/bot] could not write AGENTS.md in %s", home)
+
+    def _detect_logged_in(self) -> bool:
+        try:
+            import tomllib
+        except Exception:
+            tomllib = None
+        home = Path.home()
+        auth = home / ".codex" / "auth.json"
+        if auth.exists() and auth.stat().st_size > 2:
+            return True
+        cfg = home / ".codex" / "config.toml"
+        if not cfg.exists() or tomllib is None:
+            return False
+        try:
+            data = tomllib.loads(cfg.read_text(encoding="utf-8", errors="ignore"))
+        except Exception:
+            return False
+        providers = data.get("model_providers") or {}
+        if not isinstance(providers, dict):
+            return False
+        credential_keys = {
+            "api_key", "experimental_bearer_token", "bearer_token", "access_token",
+        }
+        for provider in providers.values():
+            if isinstance(provider, dict) and credential_keys.intersection(provider):
+                return True
+        return False
+
+    async def probe(self) -> ProviderStatus:
+        now = time.monotonic()
+        if self._probe_cache and now - self._probe_cache[0] < _PROBE_CACHE_S:
+            return self._probe_cache[1]
+        argv = resolve_codex_command()
+        if not argv:
+            status = ProviderStatus(available=False, detail="codex executable not found")
+            self._probe_cache = (now, status)
+            return status
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv, "--version",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            out, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
+            version = (out or b"").decode("utf-8", "replace").strip()
+        except (OSError, asyncio.TimeoutError) as e:
+            status = ProviderStatus(available=False, detail=f"version check failed: {e}")
+            self._probe_cache = (now, status)
+            return status
+        status = ProviderStatus(
+            available=True,
+            version=version,
+            logged_in=self._detect_logged_in(),
+        )
+        self._probe_cache = (now, status)
+        return status
+
+    def _mcp_lockdown_args(self) -> list[str]:
+        """Disable every user-configured MCP server except ``comfytv``."""
+        args: list[str] = []
+        try:
+            import tomllib
+        except Exception:
+            return args
+        cfg = Path.home() / ".codex" / "config.toml"
+        if not cfg.exists():
+            return args
+        try:
+            data = tomllib.loads(cfg.read_text(encoding="utf-8", errors="ignore"))
+        except Exception:
+            return args
+        servers = data.get("mcp_servers") or {}
+        if not isinstance(servers, dict):
+            return args
+        for server_id in servers:
+            if server_id != "comfytv":
+                args += ["-c", f"mcp_servers.{server_id}.enabled=false"]
+        return args
+
+    def _write_attachment(self, home: str, data: str, media_type: str) -> Optional[str]:
+        try:
+            raw = base64.b64decode(data)
+        except Exception:
+            return None
+        if not raw:
+            return None
+        out_dir = os.path.join(home, "attachments")
+        os.makedirs(out_dir, exist_ok=True)
+        ext = _MEDIA_EXT.get(media_type, ".bin")
+        path = os.path.join(out_dir, f"att-{int(time.time() * 1000)}{ext}")
+        with open(path, "wb") as fh:
+            fh.write(raw)
+        return path
+
+    def _build_argv(self, turn: TurnRequest, home: str) -> tuple[list[str], list[str]]:
+        argv = resolve_codex_command()
+        if not argv:
+            raise RuntimeError("codex executable not found")
+
+        # Note: sessions must be persisted (no --ephemeral) so that the
+        # thread_id returned by `thread.started` can be resumed on the next turn.
+        flags = ["--json", "--skip-git-repo-check"]
+
+        if turn.mcp_endpoint:
+            flags += [
+                "-c", 'mcp_servers.comfytv.url="%s"' % turn.mcp_endpoint,
+                "-c", "mcp_servers.comfytv.required=true",
+            ]
+        flags += self._mcp_lockdown_args()
+        # The ComfyTV bot is only meant to drive the canvas: no local shell, no web.
+        flags += ["-c", "features.shell_tool=false"]
+        flags += ["-c", 'web_search="disabled"']
+        if not turn.resume_token:
+            # `codex exec resume` does not accept --sandbox; apply it only on the
+            # first turn and let subsequent resumed turns inherit the session.
+            flags += ["--sandbox", "read-only"]
+
+        temp_files: list[str] = []
+        for att in turn.attachments:
+            data = att.get("data")
+            if not data:
+                continue
+            path = self._write_attachment(
+                home, data, str(att.get("media_type") or "image/jpeg"))
+            if path:
+                temp_files.append(path)
+                flags += ["-i", path]
+
+        argv = argv + ["exec"]
+        if turn.resume_token:
+            argv += ["resume"]
+        argv += flags
+        if turn.resume_token:
+            argv.append(turn.resume_token)
+        argv.append(turn.user_text)
+        return argv, temp_files
+
+    async def send(self, turn: TurnRequest, emit: EmitFn,
+                   handle: TurnHandle) -> TurnResult:
+        home = self._resolve_home()
+        argv, temp_files = self._build_argv(turn, home)
+
+        kwargs: dict = {
+            "stdout": asyncio.subprocess.PIPE,
+            "stderr": asyncio.subprocess.PIPE,
+            "stdin": asyncio.subprocess.DEVNULL,
+            "cwd": home,
+            "limit": _STREAM_LIMIT,
+            "env": spawn_env(),
+        }
+        if sys.platform == "win32":
+            kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            kwargs["start_new_session"] = True
+
+        proc = await asyncio.create_subprocess_exec(*argv, **kwargs)
+        handle.process = proc
+        parser = _StreamParser()
+        stderr_buf: list[bytes] = []
+
+        async def _drain_stderr() -> None:
+            while True:
+                chunk = await proc.stderr.read(65536)
+                if not chunk:
+                    return
+                if sum(len(c) for c in stderr_buf) < 65536:
+                    stderr_buf.append(chunk)
+
+        stderr_task = asyncio.create_task(_drain_stderr())
+        try:
+            deadline = time.monotonic() + _TURN_TIMEOUT_S
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise asyncio.TimeoutError()
+                try:
+                    line = await asyncio.wait_for(
+                        proc.stdout.readline(), timeout=remaining)
+                except ValueError:
+                    _log.warning("[ComfyTV/bot] oversized stream line skipped")
+                    continue
+                if not line:
+                    break
+                for ev in parser.parse_line(line.decode("utf-8", "replace")):
+                    await emit(ev)
+            await proc.wait()
+        except asyncio.TimeoutError:
+            await self.stop(handle)
+            return TurnResult(
+                resume_token=parser.session_id, error="turn timed out", aborted=True)
+        finally:
+            stderr_task.cancel()
+            for path in temp_files:
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+
+        if handle.stop_requested:
+            return TurnResult(resume_token=parser.session_id, aborted=True)
+        if parser.result_error:
+            return TurnResult(
+                resume_token=parser.session_id, error=parser.result_error)
+        if proc.returncode not in (0, None) or not parser.result_seen:
+            err = b"".join(stderr_buf).decode("utf-8", "replace").strip()
+            return TurnResult(
+                resume_token=parser.session_id,
+                error=err[-800:] or f"codex exited with code {proc.returncode}",
+            )
+        return TurnResult(resume_token=parser.session_id)
+
+    async def stop(self, handle: TurnHandle) -> None:
+        handle.stop_requested = True
+        proc = handle.process
+        if proc is None or proc.returncode is not None:
+            return
+        try:
+            if sys.platform == "win32":
+                await asyncio.create_subprocess_exec(
+                    "taskkill", "/F", "/T", "/PID", str(proc.pid),
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+            else:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (OSError, ProcessLookupError):
+            pass
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=10)
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except (OSError, ProcessLookupError):
+                pass

--- a/docs-site/guides/bot.mdx
+++ b/docs-site/guides/bot.mdx
@@ -18,12 +18,13 @@ Typical asks:
 
 ## No API keys, by design
 
-The bot does not talk to any model API directly and ComfyTV never stores a key. Instead it drives the **agent CLI already installed on your machine** — currently [Claude Code](https://claude.com/claude-code) — using whatever login that CLI has (e.g. your subscription). The provider layer is pluggable, so other local agent CLIs can be added later.
+The bot does not talk to any model API directly and ComfyTV never stores a key. Instead it drives the **agent CLI already installed on your machine** — [Claude Code](https://claude.com/claude-code) or [Codex](https://developers.openai.com/codex) — using whatever login that CLI has (e.g. your subscription). The provider layer is pluggable, so other local agent CLIs can be added later.
 
 Prerequisites:
 
 1. Install Claude Code and sign in once (`npm install -g @anthropic-ai/claude-code`, then `claude` → login).
-2. In ComfyTV **Settings → Agent & MCP**, enable **MCP server** and then **ComfyTV Bot** (the bot requires MCP — it's how the agent reaches your canvas).
+2. Or install the Codex CLI and sign in once (`codex login`). When both CLIs are present, Codex is used first.
+3. In ComfyTV **Settings → Agent & MCP**, enable **MCP server** and then **ComfyTV Bot** (the bot requires MCP — it's how the agent reaches your canvas).
 
 If no agent CLI is found, the panel shows an install guide instead of a chat box.
 
@@ -43,7 +44,7 @@ Each turn spawns a fresh CLI process in headless mode, locked down to the ComfyT
 | Symptom | Cause / fix |
 |---|---|
 | No ✨ icon in the sidebar | **Enable ComfyTV Bot** is off (Settings → Agent & MCP), which itself requires **Enable MCP server** |
-| Panel shows an install guide | No agent CLI found — install Claude Code and sign in, then *Check again* |
+| Panel shows an install guide | No agent CLI found — install Claude Code or Codex and sign in, then *Check again* |
 | Bot says it can't reach the canvas | No ComfyTV tab open (or tab websocket dropped after a server restart — hard-refresh) |
 | Long renders: bot seems idle | It's inside a blocking `wait_stage` — the tool chip shows it; this is normal and cheap |
 

--- a/docs-site/guides/mcp.mdx
+++ b/docs-site/guides/mcp.mdx
@@ -21,7 +21,36 @@ For Claude Code:
 claude mcp add --transport http comfytv http://127.0.0.1:8188/comfytv/mcp
 ```
 
-Any other MCP client: point it at the same URL with the streamable HTTP transport. The server is stateless; no auth is added on top of your ComfyUI instance, so treat network exposure of port 8188 accordingly.
+For Codex, add the server to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.comfytv]
+url = "http://127.0.0.1:8188/comfytv/mcp"
+```
+
+Any other MCP client: point it at the same URL with the streamable HTTP transport.
+The handlers are stateless, but the server issues an `Mcp-Session-Id` on
+`initialize` for clients that expect streamable-HTTP session management. No auth
+is added on top of your ComfyUI instance, so treat network exposure of port 8188
+accordingly.
+
+## Resource bridge
+
+Some MCP clients (for example, the current Codex CLI) surface a server's MCP
+*resources* to the model but not its *tools*. For those clients ComfyTV also
+publishes every tool as a resource, so the same canvas-driving capabilities stay
+reachable through `read_mcp_resource`:
+
+| URI | What it does |
+|---|---|
+| `comfytv://help` | Full tool catalog: names, descriptions and input schemas. |
+| `comfytv://tool/<name>` | One tool's description and input schema. |
+| `comfytv://call/<name>` | Call a tool with no arguments. |
+| `comfytv://call/<name>?<url-encoded-json>` | Call a tool with JSON arguments. |
+
+Example: `read_mcp_resource(server="comfytv", uri="comfytv://call/server_info")`
+returns the ComfyTV version and project count. The ComfyTV Bot uses this same
+bridge when it is driven by the Codex provider.
 
 ## The tool catalog
 

--- a/docs-site/zh/guides/bot.mdx
+++ b/docs-site/zh/guides/bot.mdx
@@ -19,12 +19,13 @@ translationSourceHash: "1f17809ecf0b1bac"
 
 ## 不碰 API key,这是设计
 
-Bot 不直接调用任何模型 API,ComfyTV 也永远不存 key。它驱动的是**你机器上已经装好的 agent CLI** — 目前是 [Claude Code](https://claude.com/claude-code) — 用那个 CLI 自己的登录态(比如你的订阅)。Provider 层是可插拔的,以后可以接入其他本地 agent CLI。
+Bot 不直接调用任何模型 API,ComfyTV 也永远不存 key。它驱动的是**你机器上已经装好的 agent CLI** — [Claude Code](https://claude.com/claude-code) 或 [Codex](https://developers.openai.com/codex) — 用那个 CLI 自己的登录态(比如你的订阅)。Provider 层是可插拔的,以后可以接入其他本地 agent CLI。
 
 前置条件:
 
 1. 装好 Claude Code 并登录一次(`npm install -g @anthropic-ai/claude-code`,然后运行 `claude` 登录)。
-2. 在 ComfyTV **设置 → Agent 与 MCP** 里,先开 **MCP 服务**,再开 **ComfyTV Bot**(Bot 依赖 MCP — 那是 agent 触达画布的通道)。
+2. 或者装好 Codex CLI 并登录一次(`codex login`)。两个 CLI 都在时,优先用 Codex。
+3. 在 ComfyTV **设置 → Agent 与 MCP** 里,先开 **MCP 服务**,再开 **ComfyTV Bot**(Bot 依赖 MCP — 那是 agent 触达画布的通道)。
 
 检测不到 agent CLI 时,面板会显示安装引导而不是聊天框。
 
@@ -44,7 +45,7 @@ Bot 不直接调用任何模型 API,ComfyTV 也永远不存 key。它驱动的�
 | 现象 | 原因 / 处理 |
 |---|---|
 | 侧边栏没有 ✨ 图标 | **启用 ComfyTV Bot** 没开(设置 → Agent 与 MCP),它又依赖**启用 MCP 服务** |
-| 面板显示安装引导 | 没检测到 agent CLI — 装 Claude Code 并登录,然后点*重新检测* |
+| 面板显示安装引导 | 没检测到 agent CLI — 装 Claude Code 或 Codex 并登录,然后点*重新检测* |
 | Bot 说够不到画布 | 没有打开的 ComfyTV tab(或服务器重启后 tab 的 websocket 断了 — 硬刷新) |
 | 长渲染时 Bot 好像没动 | 它在 `wait_stage` 里阻塞等待 — 工具条目能看到;正常且省钱 |
 

--- a/docs-site/zh/guides/mcp.mdx
+++ b/docs-site/zh/guides/mcp.mdx
@@ -22,7 +22,27 @@ Claude Code:
 claude mcp add --transport http comfytv http://127.0.0.1:8188/comfytv/mcp
 ```
 
-其他 MCP 客户端:用 streamable HTTP 指向同一 URL。服务无状态,不在 ComfyUI 之上附加鉴权 — 8188 端口的网络暴露请自行斟酌。
+Codex:把服务器加到 `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.comfytv]
+url = "http://127.0.0.1:8188/comfytv/mcp"
+```
+
+其他 MCP 客户端:用 streamable HTTP 指向同一 URL。处理器本身仍是无状态的,但服务器会在 `initialize` 时签发一个 `Mcp-Session-Id`,以兼容期望 streamable-HTTP 会话管理的客户端。不在 ComfyUI 之上附加鉴权 — 8188 端口的网络暴露请自行斟酌。
+
+## 资源桥
+
+有些 MCP 客户端(例如当前版本的 Codex CLI)只会把服务器的 MCP *资源(resources)* 暴露给模型,而不会暴露它的 *工具(tools)*。为了让这类客户端也能驱动画布,ComfyTV 把每个工具也发布成一个资源,通过 `read_mcp_resource` 即可触达:
+
+| URI | 作用 |
+|---|---|
+| `comfytv://help` | 完整工具目录:名称、描述与入参 schema。 |
+| `comfytv://tool/<name>` | 单个工具的描述与入参 schema。 |
+| `comfytv://call/<name>` | 无参调用一个工具。 |
+| `comfytv://call/<name>?<url-encoded-json>` | 带 JSON 参数调用一个工具。 |
+
+示例:`read_mcp_resource(server="comfytv", uri="comfytv://call/server_info")` 会返回 ComfyTV 版本与项目数。ComfyTV Bot 由 Codex provider 驱动时,走的就是这套资源桥。
 
 ## 工具目录
 

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -19,12 +19,13 @@ Typical asks:
 
 ## No API keys, by design
 
-The bot does not talk to any model API directly and ComfyTV never stores a key. Instead it drives the **agent CLI already installed on your machine** — currently [Claude Code](https://claude.com/claude-code) — using whatever login that CLI has (e.g. your subscription). The provider layer is pluggable, so other local agent CLIs can be added later.
+The bot does not talk to any model API directly and ComfyTV never stores a key. Instead it drives the **agent CLI already installed on your machine** — [Claude Code](https://claude.com/claude-code) or [Codex](https://developers.openai.com/codex) — using whatever login that CLI has (e.g. your subscription). The provider layer is pluggable, so other local agent CLIs can be added later.
 
 Prerequisites:
 
 1. Install Claude Code and sign in once (`npm install -g @anthropic-ai/claude-code`, then `claude` → login).
-2. In ComfyTV **Settings → Agent & MCP**, enable **MCP server** and then **ComfyTV Bot** (the bot requires MCP — it's how the agent reaches your canvas).
+2. Or install the Codex CLI and sign in once (`codex login`). When both CLIs are present, Codex is used first.
+3. In ComfyTV **Settings → Agent & MCP**, enable **MCP server** and then **ComfyTV Bot** (the bot requires MCP — it's how the agent reaches your canvas).
 
 If no agent CLI is found, the panel shows an install guide instead of a chat box.
 
@@ -44,7 +45,7 @@ Each turn spawns a fresh CLI process in headless mode, locked down to the ComfyT
 | Symptom | Cause / fix |
 |---|---|
 | No ✨ icon in the sidebar | **Enable ComfyTV Bot** is off (Settings → Agent & MCP), which itself requires **Enable MCP server** |
-| Panel shows an install guide | No agent CLI found — install Claude Code and sign in, then *Check again* |
+| Panel shows an install guide | No agent CLI found — install Claude Code or Codex and sign in, then *Check again* |
 | Bot says it can't reach the canvas | No ComfyTV tab open (or tab websocket dropped after a server restart — hard-refresh) |
 | Long renders: bot seems idle | It's inside a blocking `wait_stage` — the tool chip shows it; this is normal and cheap |
 

--- a/docs/bot.zh.md
+++ b/docs/bot.zh.md
@@ -19,12 +19,13 @@
 
 ## 不碰 API key,这是设计
 
-Bot 不直接调用任何模型 API,ComfyTV 也永远不存 key。它驱动的是**你机器上已经装好的 agent CLI** — 目前是 [Claude Code](https://claude.com/claude-code) — 用那个 CLI 自己的登录态(比如你的订阅)。Provider 层是可插拔的,以后可以接入其他本地 agent CLI。
+Bot 不直接调用任何模型 API,ComfyTV 也永远不存 key。它驱动的是**你机器上已经装好的 agent CLI** — [Claude Code](https://claude.com/claude-code) 或 [Codex](https://developers.openai.com/codex) — 用那个 CLI 自己的登录态(比如你的订阅)。Provider 层是可插拔的,以后可以接入其他本地 agent CLI。
 
 前置条件:
 
 1. 装好 Claude Code 并登录一次(`npm install -g @anthropic-ai/claude-code`,然后运行 `claude` 登录)。
-2. 在 ComfyTV **设置 → Agent 与 MCP** 里,先开 **MCP 服务**,再开 **ComfyTV Bot**(Bot 依赖 MCP — 那是 agent 触达画布的通道)。
+2. 或者装好 Codex CLI 并登录一次(`codex login`)。两个 CLI 都在时,优先用 Codex。
+3. 在 ComfyTV **设置 → Agent 与 MCP** 里,先开 **MCP 服务**,再开 **ComfyTV Bot**(Bot 依赖 MCP — 那是 agent 触达画布的通道)。
 
 检测不到 agent CLI 时,面板会显示安装引导而不是聊天框。
 
@@ -44,7 +45,7 @@ Bot 不直接调用任何模型 API,ComfyTV 也永远不存 key。它驱动的�
 | 现象 | 原因 / 处理 |
 |---|---|
 | 侧边栏没有 ✨ 图标 | **启用 ComfyTV Bot** 没开(设置 → Agent 与 MCP),它又依赖**启用 MCP 服务** |
-| 面板显示安装引导 | 没检测到 agent CLI — 装 Claude Code 并登录,然后点*重新检测* |
+| 面板显示安装引导 | 没检测到 agent CLI — 装 Claude Code 或 Codex 并登录,然后点*重新检测* |
 | Bot 说够不到画布 | 没有打开的 ComfyTV tab(或服务器重启后 tab 的 websocket 断了 — 硬刷新) |
 | 长渲染时 Bot 好像没动 | 它在 `wait_stage` 里阻塞等待 — 工具条目能看到;正常且省钱 |
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -22,7 +22,36 @@ For Claude Code:
 claude mcp add --transport http comfytv http://127.0.0.1:8188/comfytv/mcp
 ```
 
-Any other MCP client: point it at the same URL with the streamable HTTP transport. The server is stateless; no auth is added on top of your ComfyUI instance, so treat network exposure of port 8188 accordingly.
+For Codex, add the server to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.comfytv]
+url = "http://127.0.0.1:8188/comfytv/mcp"
+```
+
+Any other MCP client: point it at the same URL with the streamable HTTP transport.
+The handlers are stateless, but the server issues an `Mcp-Session-Id` on
+`initialize` for clients that expect streamable-HTTP session management. No auth
+is added on top of your ComfyUI instance, so treat network exposure of port 8188
+accordingly.
+
+## Resource bridge
+
+Some MCP clients (for example, the current Codex CLI) surface a server's MCP
+*resources* to the model but not its *tools*. For those clients ComfyTV also
+publishes every tool as a resource, so the same canvas-driving capabilities stay
+reachable through `read_mcp_resource`:
+
+| URI | What it does |
+|---|---|
+| `comfytv://help` | Full tool catalog: names, descriptions and input schemas. |
+| `comfytv://tool/<name>` | One tool's description and input schema. |
+| `comfytv://call/<name>` | Call a tool with no arguments. |
+| `comfytv://call/<name>?<url-encoded-json>` | Call a tool with JSON arguments. |
+
+Example: `read_mcp_resource(server="comfytv", uri="comfytv://call/server_info")`
+returns the ComfyTV version and project count. The [ComfyTV Bot](bot.md) uses this
+same bridge when it is driven by the Codex provider.
 
 ## The tool catalog
 

--- a/docs/mcp.zh.md
+++ b/docs/mcp.zh.md
@@ -22,7 +22,27 @@ Claude Code:
 claude mcp add --transport http comfytv http://127.0.0.1:8188/comfytv/mcp
 ```
 
-其他 MCP 客户端:用 streamable HTTP 指向同一 URL。服务无状态,不在 ComfyUI 之上附加鉴权 — 8188 端口的网络暴露请自行斟酌。
+Codex:把服务器加到 `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.comfytv]
+url = "http://127.0.0.1:8188/comfytv/mcp"
+```
+
+其他 MCP 客户端:用 streamable HTTP 指向同一 URL。处理器本身仍是无状态的,但服务器会在 `initialize` 时签发一个 `Mcp-Session-Id`,以兼容期望 streamable-HTTP 会话管理的客户端。不在 ComfyUI 之上附加鉴权 — 8188 端口的网络暴露请自行斟酌。
+
+## 资源桥
+
+有些 MCP 客户端(例如当前版本的 Codex CLI)只会把服务器的 MCP *资源(resources)* 暴露给模型,而不会暴露它的 *工具(tools)*。为了让这类客户端也能驱动画布,ComfyTV 把每个工具也发布成一个资源,通过 `read_mcp_resource` 即可触达:
+
+| URI | 作用 |
+|---|---|
+| `comfytv://help` | 完整工具目录:名称、描述与入参 schema。 |
+| `comfytv://tool/<name>` | 单个工具的描述与入参 schema。 |
+| `comfytv://call/<name>` | 无参调用一个工具。 |
+| `comfytv://call/<name>?<url-encoded-json>` | 带 JSON 参数调用一个工具。 |
+
+示例:`read_mcp_resource(server="comfytv", uri="comfytv://call/server_info")` 会返回 ComfyTV 版本与项目数。[ComfyTV Bot](bot.zh.md) 由 Codex provider 驱动时,走的就是这套资源桥。
 
 ## 工具目录
 


### PR DESCRIPTION
## ComfyTV Bot Codex通用接口

Adds a **Codex** agent provider for the ComfyTV Bot and a **resource bridge** on the MCP endpoint, so resource-only MCP clients (such as the current Codex CLI) can drive the canvas.

## Why

- `bot/claude_code.py` works because Claude Code exposes MCP *tools* (`--allowedTools mcp__comfytv__*`).
- The current Codex CLI (`codex exec`) surfaces MCP *resources* to the model but not MCP *tools*; its model-facing MCP surface is `list_mcp_resources` / `list_mcp_resource_templates` / `read_mcp_resource`.
- To bridge that gap, every ComfyTV tool is also published as a resource:

| URI | Purpose |
|---|---|
| `comfytv://help` | Full tool catalog: names, descriptions, input schemas. |
| `comfytv://tool/<name>` | One tool's description and input schema. |
| `comfytv://call/<name>` | Call a tool with no arguments. |
| `comfytv://call/<name>?<url-encoded-json>` | Call a tool with JSON arguments. |

## Changes

- `bot/codex.py` (new): `CodexCodeProvider` mirroring `ClaudeCodeProvider`. It spawns `codex exec --json`, parses the JSONL stream into the bot's `delta` / `tool_use` / `tool_result` events, resumes via the `thread_id`, and writes an `AGENTS.md` that instructs Codex to use the resource bridge.
- `bot/__init__.py`: register `CodexCodeProvider` (Codex is preferred when both CLIs are present).
- `api/mcp.py`:
  - add `resources/list`, `resources/templates/list`, and `resources/read`;
  - add an empty `prompts/list`;
  - issue `Mcp-Session-Id` on `initialize` and return `200` on `DELETE` for streamable-HTTP session compatibility.
- Docs (English + 简体中文) in `docs/` and `docs-site/` updated for Codex and the resource bridge.

## Verified

Tested end-to-end on local ComfyUI 0.33.0 + ComfyTV 1.9.0: Codex read the catalog, added an image stage, ran it, waited through a multi-minute render, and returned the output image URL.

## Notes

- Write tools still require an open ComfyTV tab (unchanged).
- If Codex later exposes MCP tools directly, the provider can switch back to direct tool calls; the resource bridge remains backwards-compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Codex CLI as a local bot provider, including setup detection, streaming responses, session continuation, and cancellation handling.
  - Added MCP streamable HTTP session support with session tracking and cleanup.
  - Added resource-based tool discovery, metadata viewing, and tool invocation for compatible clients.

- **Documentation**
  - Updated English and Chinese guides with Codex setup instructions, MCP configuration, session behavior, resource access, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->