### PR TITLE
fix: pin xfade color matrix (per-generation yellow drift) + fx_previe…

### DIFF
--- a/api/mcp_tools.py
+++ b/api/mcp_tools.py
@@ -757,6 +757,59 @@ async def _view_image(args: dict) -> dict:
             "extract a frame with media_frame first")
 
 
+_FX_PREVIEW_WINDOW_DEFAULT = 1.2
+_FX_PREVIEW_WINDOW_MIN = 0.4
+_FX_PREVIEW_WINDOW_MAX = 3.0
+
+
+async def _fx_preview(args: dict) -> dict:
+    node_class = _normalize_stage_class(str(args.get("node_class") or ""))
+    if node_class.removeprefix("ComfyTV.") == "FXChainStage":
+        raise ValueError(
+            "FXChainStage renders the whole chain — preview individual FX "
+            "stages here, then run the chain node for the final output")
+    url = str(args.get("video") or "")
+    if not url:
+        raise ValueError("video is required (a /view?… video payload_url)")
+    params = args.get("params") or {}
+    if not isinstance(params, dict):
+        raise ValueError("params must be an object of widget values")
+    try:
+        t = float(args.get("t", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        raise ValueError("t must be a number (seconds into the video)")
+    try:
+        window = float(args.get("window") or _FX_PREVIEW_WINDOW_DEFAULT)
+    except (TypeError, ValueError):
+        raise ValueError("window must be a number (seconds)")
+    window = max(_FX_PREVIEW_WINDOW_MIN,
+                 min(_FX_PREVIEW_WINDOW_MAX, window))
+
+    from .fx_preview import _render_preview, _spec_from_stage
+    from .presets import _stage_class_map
+    stage_cls = (await _stage_class_map()).get(node_class)
+    if stage_cls is None:
+        raise ValueError(f"unknown node_class {node_class!r}")
+    try:
+        data = _spec_from_stage(node_class, stage_cls, params, url)
+    except Exception as e:
+        raise ValueError(f"{node_class} does not support fx preview: {e}")
+    result = await asyncio.to_thread(_render_preview, url, data, t, window)
+
+    from ..runners import media
+    frame_url = await asyncio.to_thread(
+        media.extract_frame, result["url"], "middle")
+    frame = await asyncio.to_thread(
+        _render_view_image, frame_url, _VIEW_MAX_PX_DEFAULT)
+    return {
+        "url": result["url"],
+        "t0": result["t0"],
+        "t1": result["t1"],
+        "frame_url": frame_url,
+        "_images": frame["_images"],
+    }
+
+
 async def _pick_output(args: dict) -> dict:
     oid = args.get("output_id")
     idx = args.get("picked_index")
@@ -1593,6 +1646,37 @@ TOOLS: dict[str, dict] = {
             "additionalProperties": False,
         },
         "handler": _view_image,
+    },
+    "fx_preview": {
+        "description": (
+            "Cheap look at what ONE FX stage would do to a video before "
+            "running anything: renders a short window (default 1.2s, max "
+            "3s, downscaled to 640px) of the video through that stage's "
+            "real filter chain and returns the preview clip URL plus its "
+            "middle frame as an actual image you can see. node_class is an "
+            "FX stage from stage_catalog (VideoColorStage, "
+            "VideoCurvesStage, CDLStage…), params are its widget values "
+            "(same names as set_stage widgets — read current ones with "
+            "get_stage), video is the source /view?… payload_url, t is "
+            "where in the video to look. Iterate params here until the "
+            "frame looks right, THEN set_stage + run the FXChainStage for "
+            "the full render — two orders of magnitude cheaper than "
+            "re-rendering the whole video per attempt. Not for "
+            "FXChainStage itself."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "node_class": {"type": "string"},
+                "video": {"type": "string"},
+                "params": {"type": "object"},
+                "t": {"type": "number"},
+                "window": {"type": "number"},
+            },
+            "required": ["node_class", "video"],
+            "additionalProperties": False,
+        },
+        "handler": _fx_preview,
     },
     "pick_output": {
         "description": (

--- a/docs-site/guides/mcp.mdx
+++ b/docs-site/guides/mcp.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent access (MCP)"
-description: "ComfyTV ships an MCP server so AI agents can read and drive your canvas: build node graphs, run stages, wait for renders, inspect results with real vision, and manage your workflow configuration — all through 35 tools."
+description: "ComfyTV ships an MCP server so AI agents can read and drive your canvas: build node graphs, run stages, wait for renders, inspect results with real vision, and manage your workflow configuration — all through 36 tools."
 ---
 
 ## What it is
@@ -55,6 +55,7 @@ Any other MCP client: point it at the same URL with the streamable HTTP transpor
 | Tool | What it does |
 |---|---|
 | `view_image` | Returns the actual image (downscaled) so the agent can look at it |
+| `fx_preview` | Render a ~1.2s window of a video through one FX stage's real filter chain and see its middle frame — iterate look params cheaply before a full render |
 | `media_probe` | Video duration/fps/resolution/audio |
 | `media_frame` | Extract a frame from a video as a PNG URL |
 | `media_waveform` | Render an audio waveform image |

--- a/docs-site/zh/guides/mcp.mdx
+++ b/docs-site/zh/guides/mcp.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent 接入(MCP)"
-description: "ComfyTV 内置 MCP 服务,让 AI agent 读取并驱动你的画布:搭建节点图、跑渲染、阻塞等待、用真视觉检查结果、管理工作流配置 — 共 35 个工具。"
+description: "ComfyTV 内置 MCP 服务,让 AI agent 读取并驱动你的画布:搭建节点图、跑渲染、阻塞等待、用真视觉检查结果、管理工作流配置 — 共 36 个工具。"
 translationSourceHash: "c0b9240706826e05"
 ---
 
@@ -56,6 +56,7 @@ claude mcp add --transport http comfytv http://127.0.0.1:8188/comfytv/mcp
 | 工具 | 作用 |
 |---|---|
 | `view_image` | 返回图像本体(缩放后),agent 能亲眼看 |
+| `fx_preview` | 把视频 ~1.2 秒窗口过一遍单个 FX 节点的真滤镜链并直接看中间帧 — 全片渲染前廉价迭代调参 |
 | `media_probe` | 视频时长/帧率/分辨率/有无音轨 |
 | `media_frame` | 从视频抽一帧,返回 PNG URL |
 | `media_waveform` | 渲染音频波形图 |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -2,7 +2,7 @@
 
 # Agent access (MCP)
 
-> ComfyTV ships an MCP server so AI agents can read and drive your canvas: build node graphs, run stages, wait for renders, inspect results with real vision, and manage your workflow configuration — all through 35 tools.
+> ComfyTV ships an MCP server so AI agents can read and drive your canvas: build node graphs, run stages, wait for renders, inspect results with real vision, and manage your workflow configuration — all through 36 tools.
 
 ## What it is
 
@@ -56,6 +56,7 @@ Any other MCP client: point it at the same URL with the streamable HTTP transpor
 | Tool | What it does |
 |---|---|
 | `view_image` | Returns the actual image (downscaled) so the agent can look at it |
+| `fx_preview` | Render a ~1.2s window of a video through one FX stage's real filter chain and see its middle frame — iterate look params cheaply before a full render |
 | `media_probe` | Video duration/fps/resolution/audio |
 | `media_frame` | Extract a frame from a video as a PNG URL |
 | `media_waveform` | Render an audio waveform image |

--- a/docs/mcp.zh.md
+++ b/docs/mcp.zh.md
@@ -2,7 +2,7 @@
 
 # Agent 接入(MCP)
 
-> ComfyTV 内置 MCP 服务,让 AI agent 读取并驱动你的画布:搭建节点图、跑渲染、阻塞等待、用真视觉检查结果、管理工作流配置 — 共 35 个工具。
+> ComfyTV 内置 MCP 服务,让 AI agent 读取并驱动你的画布:搭建节点图、跑渲染、阻塞等待、用真视觉检查结果、管理工作流配置 — 共 36 个工具。
 
 ## 是什么
 
@@ -56,6 +56,7 @@ claude mcp add --transport http comfytv http://127.0.0.1:8188/comfytv/mcp
 | 工具 | 作用 |
 |---|---|
 | `view_image` | 返回图像本体(缩放后),agent 能亲眼看 |
+| `fx_preview` | 把视频 ~1.2 秒窗口过一遍单个 FX 节点的真滤镜链并直接看中间帧 — 全片渲染前廉价迭代调参 |
 | `media_probe` | 视频时长/帧率/分辨率/有无音轨 |
 | `media_frame` | 从视频抽一帧,返回 PNG URL |
 | `media_waveform` | 渲染音频波形图 |

--- a/runners/media_filter.py
+++ b/runners/media_filter.py
@@ -468,11 +468,17 @@ def xfade_videos(url_a: str, url_b: str, transition: str = 'fade',
 
         graph = av.filter.Graph()
 
+        out_matrix = _CS_FILTER_NAMES.get(
+            getattr(va.codec_context, 'colorspace', None), 'bt709')
+
         def _norm_chain(stream):
+            in_matrix = _CS_FILTER_NAMES.get(
+                getattr(stream.codec_context, 'colorspace', None), out_matrix)
             buf = graph.add_buffer(template=stream)
             chain = buf
             for name, args in (
-                ('scale', f'{w}:{h}:flags=bicubic'),
+                ('scale', f'{w}:{h}:flags=bicubic:'
+                          f'in_color_matrix={in_matrix}:out_color_matrix={out_matrix}'),
                 ('fps', f'{fps}'),
                 ('format', 'yuv420p'),
                 ('settb', 'AVTB'),

--- a/tests/test_fx_preview.py
+++ b/tests/test_fx_preview.py
@@ -169,6 +169,59 @@ class TestFxPreviewEndpoint:
         assert diff > 1.0
 
 
+class TestMcpFxPreviewTool:
+    async def test_renders_window_and_returns_frame(self, reset_db, noise_clip):
+        from ComfyTV.api import mcp_tools
+        out = await mcp_tools._fx_preview({
+            'node_class': 'VideoDenoiseStage',
+            'video': noise_clip,
+            'params': {'method': 'atadenoise', 'strength': 0.5},
+            't': 1.5,
+        })
+        assert out['url'].startswith('/view?')
+        assert out['t1'] - out['t0'] == pytest.approx(1.2, abs=0.01)
+        assert out['frame_url'].startswith('/view?')
+        images = out['_images']
+        assert images and images[0]['mime'] == 'image/jpeg'
+        assert images[0]['data']
+
+    async def test_window_clamped(self, reset_db, noise_clip):
+        from ComfyTV.api import mcp_tools
+        out = await mcp_tools._fx_preview({
+            'node_class': 'VideoDenoiseStage',
+            'video': noise_clip,
+            'params': {'method': 'atadenoise', 'strength': 0.5},
+            'window': 99,
+        })
+        assert out['t1'] - out['t0'] == pytest.approx(3.0, abs=0.1)
+
+    async def test_unknown_class_rejected(self, reset_db):
+        from ComfyTV.api import mcp_tools
+        with pytest.raises(ValueError, match='unknown stage class'):
+            await mcp_tools._fx_preview({'node_class': 'NopeStage',
+                                         'video': '/view?x'})
+
+    async def test_chain_stage_rejected(self, reset_db):
+        from ComfyTV.api import mcp_tools
+        with pytest.raises(ValueError, match='FXChainStage'):
+            await mcp_tools._fx_preview({'node_class': 'FXChainStage',
+                                         'video': '/view?x'})
+
+    async def test_video_required(self, reset_db):
+        from ComfyTV.api import mcp_tools
+        with pytest.raises(ValueError, match='video is required'):
+            await mcp_tools._fx_preview({'node_class': 'VideoDenoiseStage'})
+
+    async def test_bad_params_surface_as_value_error(self, reset_db, noise_clip):
+        from ComfyTV.api import mcp_tools
+        with pytest.raises(ValueError, match='does not support fx preview'):
+            await mcp_tools._fx_preview({
+                'node_class': 'VideoDenoiseStage',
+                'video': noise_clip,
+                'params': {'method': 'atadenoise', 'strength': 0},
+            })
+
+
 class TestColorspaceFilter:
     def test_scale_then_colorspace_renders(self, clip_av):
         from ComfyTV.runners import media, media_filter as mf

--- a/tests/test_mcp_api.py
+++ b/tests/test_mcp_api.py
@@ -122,7 +122,8 @@ class TestProtocol:
             "workflow_get", "workflow_edit", "asset_edit", "entries",
             "resources", "stage_params", "media_probe", "media_frame",
             "media_waveform", "pick_output", "cancel_stage", "get_stage",
-            "director_get", "director_edit", "view_image", "arrange_canvas",
+            "director_get", "director_edit", "view_image", "fx_preview",
+            "arrange_canvas",
             "scene_get", "scene_edit", "scene_capture", "scene_record",
         }
         for t in tools.values():

--- a/tests/test_media_filter.py
+++ b/tests/test_media_filter.py
@@ -111,6 +111,55 @@ class TestXfade:
             mf.xfade_videos(clip_av, clip_b, transition='sparkle')
 
 
+class TestXfadeColorFidelity:
+    @staticmethod
+    def _write_tagged_clip(path):
+        from fractions import Fraction
+        with av.open(str(path), 'w') as out:
+            v = out.add_stream('libx264', rate=24)
+            v.width, v.height = 160, 120
+            v.pix_fmt = 'yuv420p'
+            v.codec_context.colorspace = 1
+            v.codec_context.color_primaries = 1
+            v.codec_context.color_trc = 1
+            arr = np.full((120, 160, 3), (200, 140, 60), dtype=np.uint8)
+            for i in range(36):
+                f = av.VideoFrame.from_ndarray(arr, format='rgb24') \
+                    .reformat(format='yuv420p')
+                f.pts = i
+                f.time_base = Fraction(1, 24)
+                for pkt in v.encode(f):
+                    out.mux(pkt)
+            for pkt in v.encode():
+                out.mux(pkt)
+
+    @staticmethod
+    def _head_chroma(view_url):
+        from ComfyTV.runners.media import localize
+        with av.open(str(localize(view_url))) as c:
+            frame = next(c.decode(c.streams.video[0]))
+            yuv = frame.to_ndarray(format='yuv420p').reshape(-1)
+            n = frame.width * frame.height
+            return (yuv[n:n + n // 4].astype(np.float64).mean(),
+                    yuv[n + n // 4:].astype(np.float64).mean())
+
+    def test_chroma_survives_repeated_transitions(self):
+        from ComfyTV.runners import media, media_filter as mf
+        import folder_paths
+        src_dir = Path(folder_paths.get_output_directory()) / 'filter-src'
+        src_dir.mkdir(parents=True, exist_ok=True)
+        p = src_dir / 'tagged709.mp4'
+        if not p.exists():
+            self._write_tagged_clip(p)
+        src = media.path_to_view_url(p)
+        u0, v0 = self._head_chroma(src)
+        gen1 = mf.xfade_videos(src, src, transition='fade', duration=0.3)
+        gen2 = mf.xfade_videos(gen1, gen1, transition='fade', duration=0.3)
+        u2, v2 = self._head_chroma(gen2)
+        assert abs(u2 - u0) < 1.0, (u0, u2)
+        assert abs(v2 - v0) < 1.0, (v0, v2)
+
+
 class TestSceneDetect:
     def test_hard_cut_found(self):
         """Two visually distinct halves welded packet-wise → one cut ≈ 1.0s."""


### PR DESCRIPTION
…w MCP tool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an FX preview tool that renders a short video segment through a selected filter stage.
  - Preview results include playable preview links and a representative frame image.
  - Added validation for video sources, timestamps, preview windows, stages, and parameters.

- **Bug Fixes**
  - Improved color consistency during video transitions and crossfades.

- **Documentation**
  - Updated MCP documentation in English and Chinese to include the new tool and revised tool count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->