### PR TITLE
[codex] fix(loader): support macOS promised-file drag & drop and refresh after upload

### DIFF
--- a/src/components/stages/StageCard.test.ts
+++ b/src/components/stages/StageCard.test.ts
@@ -13,6 +13,12 @@ vi.mock('./MainPromptInput.vue', () => ({
 
 const fetchStageDefaults = vi.fn()
 const listStagePresets = vi.fn()
+const uploadBlobNamed = vi.hoisted(() => vi.fn(async (file: File) => ({
+  name: file.name,
+  subfolder: '',
+  type: 'input',
+  url: `/view?filename=${encodeURIComponent(file.name)}&type=input`,
+})))
 vi.mock('@/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/api')>()
   return {
@@ -20,6 +26,10 @@ vi.mock('@/api', async (importOriginal) => {
     fetchStageDefaults: (...a: unknown[]) => fetchStageDefaults(...a),
     listStagePresets: (...a: unknown[]) => listStagePresets(...a),
   }
+})
+vi.mock('@/utils/uploadCanvas', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/uploadCanvas')>()
+  return { ...actual, uploadBlobNamed }
 })
 
 function makeState(over: Partial<StageState> = {}): StageState {
@@ -118,6 +128,42 @@ describe('StageCard — base states', () => {
     renderCard(makeState({ variant: 'loader', kind: 'image' }))
     const runBtns = document.querySelectorAll('.run-btn')
     expect(runBtns).toHaveLength(0)
+  })
+
+  it('accepts a macOS promised image dropped directly on the photo preview', async () => {
+    const widget = {
+      name: 'image',
+      value: 'old.png',
+      options: { values: ['old.png'] },
+      callback: vi.fn(),
+    }
+    const { container } = renderCard(makeState({
+      variant: 'loader',
+      kind: 'image',
+      output: '/view?filename=old.png&type=input',
+    }), {
+      node: { comfyClass: 'ComfyTV.ImageLoaderStage', widgets: [widget] },
+    })
+    const preview = container.querySelector('img') as HTMLImageElement
+    expect(preview).toBeInTheDocument()
+    preview.addEventListener('drop', (event) => event.stopPropagation())
+
+    const photo = new File(['new image'], 'Photos Export.HEIC', { type: '' })
+    const event = new Event('drop', { bubbles: true, cancelable: true }) as DragEvent
+    Object.defineProperty(event, 'dataTransfer', { value: {
+      types: ['com.apple.filepromise'],
+      items: [{ kind: 'file', type: '' }],
+      files: [photo],
+      dropEffect: 'none',
+      getData: () => '',
+    } })
+    preview.dispatchEvent(event)
+
+    await waitFor(() => expect(uploadBlobNamed).toHaveBeenCalledWith(photo, {
+      subfolder: '',
+      filename: 'Photos Export.HEIC',
+    }))
+    await waitFor(() => expect(widget.value).toBe('Photos Export.HEIC'))
   })
 
   it('hides the run button for image-picker kind', () => {

--- a/src/components/stages/StageCard.vue
+++ b/src/components/stages/StageCard.vue
@@ -1,10 +1,10 @@
 <template>
   <div
     :class="cardClass"
-    @dragenter="onCardDragEnter"
-    @dragover="onCardDragOver"
-    @dragleave="onCardDragLeave"
-    @drop="onCardDrop"
+    @dragenter.capture="onCardDragEnter"
+    @dragover.capture="onCardDragOver"
+    @dragleave.capture="onCardDragLeave"
+    @drop.capture="onCardDrop"
   >
     <MainPromptInput v-if="!hidePrompt" :node="node" />
 

--- a/src/composables/stages/useLoaderFileDrop.test.ts
+++ b/src/composables/stages/useLoaderFileDrop.test.ts
@@ -72,7 +72,7 @@ describe('useLoaderFileDrop — drag over', () => {
     }
   })
 
-  it('claims unknown-MIME file drags only for the model kind', () => {
+  it('provisionally claims unknown-MIME promised files for every loader kind', () => {
     const blank = () => dragEvent({ types: ['Files'], items: [{ kind: 'file', type: '' }] })
     const model = useLoaderFileDrop({ kind: () => 'model', onFiles: vi.fn() })
     const image = useLoaderFileDrop({ kind: () => 'image', onFiles: vi.fn() })
@@ -81,7 +81,18 @@ describe('useLoaderFileDrop — drag over', () => {
     expect(e1.preventDefault).toHaveBeenCalled()
     const e2 = blank()
     image.onDragOver(e2)
-    expect(e2.preventDefault).not.toHaveBeenCalled()
+    expect(e2.preventDefault).toHaveBeenCalled()
+  })
+
+  it('recognizes macOS promised-file drags without the Files type', () => {
+    const drop = useLoaderFileDrop({ kind: () => 'image', onFiles: vi.fn() })
+    const e = dragEvent({
+      types: ['com.apple.filepromise'],
+      items: [{ kind: 'file', type: 'image/png' }],
+    })
+    drop.onDragOver(e)
+    expect(e.preventDefault).toHaveBeenCalled()
+    expect(e.dataTransfer!.dropEffect).toBe('copy')
   })
 
   it('claims asset drags only when onAsset is provided', () => {
@@ -120,6 +131,20 @@ describe('useLoaderFileDrop — file drops', () => {
     expect(e.stopPropagation).toHaveBeenCalled()
     expect(onFiles).toHaveBeenCalledWith([img])
     expect(drop.dragActive.value).toBe(false)
+  })
+
+  it('loads a promised image whose MIME is empty once its filename is available', () => {
+    const onFiles = vi.fn()
+    const drop = useLoaderFileDrop({ kind: () => 'image', onFiles })
+    const photo = new File(['x'], 'Photos Export.HEIC', { type: '' })
+    const e = dragEvent({
+      types: ['com.apple.filepromise'],
+      items: [{ kind: 'file', type: '' }],
+      files: [photo],
+    })
+    drop.onDrop(e)
+    expect(e.preventDefault).toHaveBeenCalled()
+    expect(onFiles).toHaveBeenCalledWith([photo])
   })
 
   it('matches 3D models by extension despite an empty MIME', () => {

--- a/src/composables/stages/useLoaderFileDrop.ts
+++ b/src/composables/stages/useLoaderFileDrop.ts
@@ -39,8 +39,12 @@ export function useLoaderFileDrop(opts: LoaderFileDropOptions) {
     !!opts.onAsset && Array.from(e.dataTransfer?.types ?? []).includes(ASSET_DRAG_MIME)
 
   const isFileDrag = (e: DragEvent): boolean =>
-    Array.from(e.dataTransfer?.types ?? []).includes('Files')
-    && !Array.from(e.dataTransfer?.types ?? []).includes(ASSET_DRAG_MIME)
+    !Array.from(e.dataTransfer?.types ?? []).includes(ASSET_DRAG_MIME)
+    && (
+      Array.from(e.dataTransfer?.types ?? []).includes('Files')
+      || (e.dataTransfer?.files?.length ?? 0) > 0
+      || Array.from(e.dataTransfer?.items ?? []).some((item) => item.kind === 'file')
+    )
 
   const claims = (e: DragEvent): boolean =>
     isAssetDrag(e)

--- a/src/composables/stages/useStageLoaderDrop.test.ts
+++ b/src/composables/stages/useStageLoaderDrop.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const uploadBlobNamed = vi.hoisted(() => vi.fn(async (f: File, ..._a: unknown[]) => ({ name: f.name })))
+const uploadBlobNamed = vi.hoisted(() => vi.fn(async (f: File, opts: { subfolder: string }) => ({
+  name: f.name,
+  subfolder: opts.subfolder,
+  type: 'input',
+  url: `/view?filename=${encodeURIComponent(f.name)}&type=input`,
+})))
 vi.mock('@/utils/uploadCanvas', () => ({ uploadBlobNamed }))
 
 import {
@@ -61,9 +66,21 @@ describe('uploadLoaderFiles', () => {
     ]
     await uploadLoaderFiles(node, 'image', files)
     expect(uploadBlobNamed).toHaveBeenCalledTimes(2)
-    expect(uploadBlobNamed.mock.calls[0][1]).toEqual({ subfolder: 'comfytv/uploads', filename: 'a.png' })
+    expect(uploadBlobNamed.mock.calls[0][1]).toEqual({ subfolder: '', filename: 'a.png' })
     expect(node.widgets[0].options.values).toEqual(['existing.png', 'a.png'])
     expect(node.widgets[0].value).toBe('existing.png')
+  })
+
+  it('refreshes the loader when an upload returns the currently selected name', async () => {
+    const node = makeLoaderNode('ComfyTV.ImageLoaderStage', ['same.png'])
+    node.widgets[0].value = 'same.png'
+    node.widgets[0].callback = vi.fn()
+
+    await uploadLoaderFiles(node, 'image', [
+      new File(['new bytes'], 'same.png', { type: 'image/png' }),
+    ])
+
+    expect(node.widgets[0].callback).toHaveBeenCalledWith('same.png')
   })
 
   it('writes nothing when no files were uploaded', async () => {

--- a/src/composables/stages/useStageLoaderDrop.ts
+++ b/src/composables/stages/useStageLoaderDrop.ts
@@ -28,13 +28,17 @@ export async function uploadLoaderFiles(
 ): Promise<void> {
   let last = ''
   for (const f of files) {
-    const uploaded = await uploadBlobNamed(f, { subfolder: 'comfytv/uploads', filename: f.name })
+    const uploaded = await uploadBlobNamed(f, { subfolder: '', filename: f.name })
     last = uploaded.name
     const w = getWidget(node, widgetName) as any
     const values = w?.options?.values
     if (Array.isArray(values) && !values.includes(last)) values.push(last)
   }
-  if (last) writeWidget(node, widgetName, last)
+  if (last) {
+    const w = getWidget(node, widgetName)
+    if (w?.value === last) w.callback?.(last)
+    else writeWidget(node, widgetName, last)
+  }
 }
 
 export function useStageLoaderDrop(getNode: () => LGraphNode | undefined) {

--- a/src/utils/mediaFileTypes.test.ts
+++ b/src/utils/mediaFileTypes.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { dragMayMatchKind, mediaTypeOf } from './mediaFileTypes'
+
+describe('mediaTypeOf', () => {
+  it('uses MIME types when the platform provides them', () => {
+    expect(mediaTypeOf(new File(['x'], 'opaque', { type: 'image/png' }))).toBe('image')
+  })
+
+  it.each([
+    ['photo.HEIC', 'image'],
+    ['clip.MOV', 'video'],
+    ['voice.M4A', 'audio'],
+  ] as const)('recognizes a promised %s file with no MIME as %s', (name, kind) => {
+    expect(mediaTypeOf(new File(['x'], name, { type: '' }))).toBe(kind)
+  })
+
+  it('does not mistake an unknown file for media', () => {
+    expect(mediaTypeOf(new File(['x'], 'workflow.json', { type: '' }))).toBeNull()
+  })
+})
+
+describe('dragMayMatchKind', () => {
+  it('allows a promised file whose MIME is hidden until drop', () => {
+    const event = {
+      dataTransfer: { items: [{ kind: 'file', type: '' }] },
+    } as unknown as DragEvent
+    expect(dragMayMatchKind(event, 'image')).toBe(true)
+  })
+})

--- a/src/utils/mediaFileTypes.ts
+++ b/src/utils/mediaFileTypes.ts
@@ -2,6 +2,24 @@ import { MODEL_FILE_EXTENSIONS } from '@/widgets/three/modelFormats'
 
 export type AssetMediaType = 'image' | 'video' | 'audio' | 'model'
 
+const IMAGE_FILE_EXTENSIONS = [
+  '.avif', '.bmp', '.gif', '.heic', '.heif', '.jpeg', '.jpg', '.jxl',
+  '.png', '.tif', '.tiff', '.webp',
+]
+const VIDEO_FILE_EXTENSIONS = [
+  '.3g2', '.3gp', '.avi', '.m4v', '.mkv', '.mov', '.mp4', '.mpeg',
+  '.mpg', '.ogv', '.webm',
+]
+const AUDIO_FILE_EXTENSIONS = [
+  '.aac', '.aif', '.aiff', '.flac', '.m4a', '.mp3', '.oga', '.ogg',
+  '.opus', '.wav', '.weba', '.wma',
+]
+
+function hasExtension(name: string, extensions: string[]): boolean {
+  const lower = name.toLowerCase()
+  return extensions.some((ext) => lower.endsWith(ext))
+}
+
 export function isModelFile(name: string): boolean {
   const lower = name.toLowerCase()
   return MODEL_FILE_EXTENSIONS.some((ext) => lower.endsWith(ext))
@@ -12,6 +30,9 @@ export function mediaTypeOf(file: File): AssetMediaType | null {
   if (file.type.startsWith('video/')) return 'video'
   if (file.type.startsWith('audio/')) return 'audio'
   if (isModelFile(file.name)) return 'model'
+  if (hasExtension(file.name, IMAGE_FILE_EXTENSIONS)) return 'image'
+  if (hasExtension(file.name, VIDEO_FILE_EXTENSIONS)) return 'video'
+  if (hasExtension(file.name, AUDIO_FILE_EXTENSIONS)) return 'audio'
   return null
 }
 
@@ -20,8 +41,9 @@ export function dragMayMatchKind(e: DragEvent, kind: AssetMediaType): boolean {
   if (!items || items.length === 0) return true
   for (const item of Array.from(items)) {
     if (item.kind !== 'file') continue
+    if (!item.type) return true
     if (kind === 'model') {
-      if (!item.type || item.type.startsWith('model/')) return true
+      if (item.type.startsWith('model/')) return true
     } else if (item.type.startsWith(`${kind}/`)) {
       return true
     }


### PR DESCRIPTION
# [codex] fix(loader): support macOS promised-file drag & drop and refresh after upload

## Summary

ComfyTV's loader drag & drop relies on `dataTransfer.types` containing `Files` and on each `DataTransferItem.type` carrying a MIME prefix. On macOS, Finder and Photos commonly expose promised files as `types: ['com.apple.filepromise']` with an empty `item.type`, so the current code rejects the drag before `onDrop`. The same empty-MIME problem also makes `mediaTypeOf()` return `null`, so the upload never starts. This PR adds a filename-extension fallback and promised-file detection, and refreshes the widget when the selected file is re-uploaded.

## Root cause

- `isFileDrag()` only accepts `dataTransfer.types.includes('Files')`.
- `dragMayMatchKind()` returns `false` when `item.type` is empty (except for the `model` kind).
- `mediaTypeOf()` only checks `file.type`, so empty-MIME files cannot be classified.
- After uploading the currently selected filename, `uploadLoaderFiles()` writes the same value without triggering the widget callback, so previews may not refresh.

## Changes

- `useLoaderFileDrop`: recognize files from `files.length` or `items` with `kind === 'file'`, even without the `Files` type.
- `mediaFileTypes`: add image/video/audio extension fallbacks for empty MIME; treat empty `item.type` as a provisional match for non-model kinds.
- `StageCard`: use capture-phase drag/drop handlers so nested previews cannot stop propagation.
- `useStageLoaderDrop`: upload plain loader files into the input root; trigger the callback when the selected value is re-uploaded.
- Add tests for all of the above.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test -- --run` (305 files / 4283 tests passed)

---

## 摘要

ComfyTV 的 Loader 拖放目前依赖 `dataTransfer.types` 包含 `Files`，并且依赖 `DataTransferItem.type` 带 MIME 前缀。macOS 上从访达/照片拖出的文件常表现为 `types: ['com.apple.filepromise']` 且 `item.type` 为空，导致现有逻辑在 `onDrop` 前就拒绝了这次拖放；空 MIME 也会让 `mediaTypeOf()` 返回 `null`，上传无法开始。本 PR 增加文件名扩展名回退、promised-file 识别，并在同名文件重新上传后刷新控件。

## 根因

- `isFileDrag()` 只认 `dataTransfer.types.includes('Files')`。
- `dragMayMatchKind()` 在 `item.type` 为空时返回 `false`（`model` 类型除外）。
- `mediaTypeOf()` 只检查 `file.type`，无法识别空 MIME 文件。
- 重新上传当前已选文件名时，`uploadLoaderFiles()` 写入相同值但不触发控件回调，预览可能不刷新。

## 改动

- `useLoaderFileDrop`：即使没有 `Files` 类型，也通过 `files.length` 或 `items` 中 `kind === 'file'` 识别文件。
- `mediaFileTypes`：为空 MIME 增加 image/video/audio 扩展名回退；空 `item.type` 对非 `model` 类型暂视为可匹配。
- `StageCard`：使用捕获阶段拖放事件，避免内层预览阻止事件冒泡。
- `useStageLoaderDrop`：将普通 Loader 上传放到 ComfyUI input 根目录；同名文件重新上传时主动触发回调。
- 增加对应测试。

## 验证

- `npm run typecheck`
- `npm run build`
- `npm test -- --run`：305 个测试文件、4283 个用例全部通过
