### PR TITLE
python 3.10及以下版本的环境没有tomllib库。

### DIFF
--- a/api/capabilities.py
+++ b/api/capabilities.py
@@ -1,5 +1,8 @@
 import logging
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 from pathlib import Path
 
 from aiohttp import web

--- a/api/capabilities.py
+++ b/api/capabilities.py
@@ -2,7 +2,12 @@ import logging
 try:
     import tomllib
 except ModuleNotFoundError:
-    import tomli as tomllib
+    try:
+        import tomli as tomllib
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "Python < 3.11 requires the optional dependency 'tomli' for TOML parsing. Install it (e.g. `pip install tomli`)."
+        ) from e
 from pathlib import Path
 
 from aiohttp import web


### PR DESCRIPTION
## Summary

Add Python 3.10 compatibility by using `tomli` as a fallback for `tomllib`.

`tomllib` is only available in the Python standard library starting from Python 3.11. Since ComfyUI environments may still use Python 3.10, importing `tomllib` directly can cause a `ModuleNotFoundError`.

This change uses `tomli` as a compatible fallback:

```python
try:
    import tomllib
except ModuleNotFoundError:
    import tomli as tomllib
```

This preserves the existing `tomllib` API usage while allowing the code to work correctly on both Python 3.10 and Python 3.11+.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when the built-in TOML parser is unavailable.
  * Added a clear error message with guidance for installing the optional TOML parsing support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->