### PR TITLE
fix: wait_stage no longer reports running for runs that failed before…

### DIFF
--- a/api/canvas_state.py
+++ b/api/canvas_state.py
@@ -9,6 +9,28 @@ STALE_AFTER_S = 30.0
 _mirrors: dict[str, dict] = {}
 
 
+def _stage_key(stage: dict) -> str:
+    uid = str(stage.get("uid") or "")
+    return uid or f"node:{stage.get('graph_node_id')}"
+
+
+def _stamp_last_runs(stages: list[dict], previous: list[dict]) -> None:
+    prev_by_key = {_stage_key(s): s for s in previous}
+    now = time.time()
+    for stage in stages:
+        run = stage.get("last_run")
+        if not isinstance(run, dict):
+            continue
+        prev_run = (prev_by_key.get(_stage_key(stage)) or {}).get("last_run")
+        if (isinstance(prev_run, dict) and "changed_at" in prev_run
+                and {k: v for k, v in prev_run.items() if k != "changed_at"} == run):
+            stamped = dict(prev_run)
+        else:
+            stamped = dict(run)
+            stamped["changed_at"] = now
+        stage["last_run"] = stamped
+
+
 def store_canvas_state(project_id: str, stages: list[dict],
                        client_id: str | None = None,
                        ws_connected: bool | None = None,
@@ -19,6 +41,7 @@ def store_canvas_state(project_id: str, stages: list[dict],
             and current.get("client_id") != client_id
             and time.time() - current["received_at"] <= STALE_AFTER_S):
         return "owned_by_other"
+    _stamp_last_runs(stages, current["stages"] if current else [])
     _mirrors[project_id] = {
         "project_id": project_id,
         "client_id": client_id,

--- a/api/mcp_tools.py
+++ b/api/mcp_tools.py
@@ -1225,6 +1225,16 @@ def _mirror_stage(project_id, node_ref: str):
     raise ValueError(f"stage {node_ref!r} not found on the mirrored canvas")
 
 
+def _error_is_current(run: dict, initial_run: dict,
+                      run_started: float | None) -> bool:
+    if run != initial_run:
+        return True
+    changed = run.get("changed_at")
+    return (run_started is not None
+            and isinstance(changed, (int, float))
+            and changed >= run_started)
+
+
 def _output_created_ts(row) -> float | None:
     from datetime import datetime, timezone
     raw = (row or {}).get("created_at")
@@ -1286,7 +1296,8 @@ async def _wait_stage(args: dict) -> dict:
             fresh = None
         if fresh is not None:
             run = dict(fresh.get("last_run") or {})
-            if run.get("status") == "error" and run != initial_run:
+            if run.get("status") == "error" \
+                    and _error_is_current(run, initial_run, run_started):
                 return {
                     "status": "error",
                     "error": run.get("error") or "stage run failed",

--- a/tests/test_mcp_wait_stage.py
+++ b/tests/test_mcp_wait_stage.py
@@ -169,3 +169,84 @@ class TestFastCompletionRace:
         monkeypatch.setattr(mcp_tools, "submit_command", submit)
         await mcp_tools._run_stage({"node": "7"})
         assert mcp_tools._RUN_STARTED == {}
+
+
+class TestFastFailureRace:
+    @pytest.fixture(autouse=True)
+    def clean_run_registry(self):
+        from ComfyTV.api import mcp_tools
+        mcp_tools._RUN_STARTED.clear()
+        yield
+        mcp_tools._RUN_STARTED.clear()
+
+    async def test_error_landed_after_run_start_is_reported(self, wait_tool):
+        import time as _time
+        from ComfyTV.api import mcp_tools
+        from ComfyTV.api.canvas_state import store_canvas_state
+        mcp_tools._RUN_STARTED[STAGE["uid"]] = _time.time() - 5
+        failed = dict(STAGE)
+        failed["last_run"] = {"status": "error", "error": "instant boom"}
+        store_canvas_state("default", [failed], client_id="tab-1")
+        out = await wait_tool({"node": "7", "timeout_s": 5})
+        assert out["status"] == "error"
+        assert out["error"] == "instant boom"
+        assert out["waited_s"] < 2
+
+    async def test_error_landed_before_run_start_still_waits(self, wait_tool):
+        import time as _time
+        from ComfyTV.api import mcp_tools
+        from ComfyTV.api.canvas_state import store_canvas_state
+        failed = dict(STAGE)
+        failed["last_run"] = {"status": "error", "error": "old failure"}
+        store_canvas_state("default", [failed], client_id="tab-1")
+        mcp_tools._RUN_STARTED[STAGE["uid"]] = _time.time() + 60
+        out = await wait_tool({"node": "7", "timeout_s": 2})
+        assert out["status"] == "running"
+
+    async def test_same_message_reerror_is_reported(self, wait_tool):
+        from ComfyTV.api.canvas_state import store_canvas_state
+        failed = dict(STAGE)
+        failed["last_run"] = {"status": "error", "error": "boom"}
+        store_canvas_state("default", [failed], client_id="tab-1")
+
+        async def _refail():
+            await asyncio.sleep(0.05)
+            running = dict(STAGE)
+            running["last_run"] = {"status": "running"}
+            store_canvas_state("default", [running], client_id="tab-1")
+            await asyncio.sleep(0.05)
+            refailed = dict(STAGE)
+            refailed["last_run"] = {"status": "error", "error": "boom"}
+            store_canvas_state("default", [refailed], client_id="tab-1")
+
+        task = asyncio.ensure_future(_refail())
+        out = await wait_tool({"node": "7", "timeout_s": 5})
+        await task
+        assert out["status"] == "error"
+        assert out["error"] == "boom"
+
+
+class TestLastRunStamping:
+    def test_first_store_stamps(self, mirror):
+        from ComfyTV.api.canvas_state import get_canvas_state
+        run = get_canvas_state("default")["stages"][0]["last_run"]
+        assert isinstance(run["changed_at"], float)
+
+    def test_unchanged_run_keeps_stamp(self, mirror):
+        from ComfyTV.api.canvas_state import get_canvas_state, store_canvas_state
+        first = get_canvas_state("default")["stages"][0]["last_run"]["changed_at"]
+        store_canvas_state("default", [dict(STAGE)], client_id="tab-1")
+        again = get_canvas_state("default")["stages"][0]["last_run"]["changed_at"]
+        assert again == first
+
+    def test_changed_run_restamps(self, mirror):
+        import time as _time
+        from ComfyTV.api.canvas_state import get_canvas_state, store_canvas_state
+        first = get_canvas_state("default")["stages"][0]["last_run"]["changed_at"]
+        _time.sleep(0.01)
+        failed = dict(STAGE)
+        failed["last_run"] = {"status": "error", "error": "boom"}
+        store_canvas_state("default", [failed], client_id="tab-1")
+        run = get_canvas_state("default")["stages"][0]["last_run"]
+        assert run["status"] == "error"
+        assert run["changed_at"] > first


### PR DESCRIPTION
… the first wait (#337)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stage monitoring to detect current-run failures more reliably, including rapid failures and repeated identical errors.
  * Preserved run timestamps for unchanged stages while refreshing them when status or error information changes.
  * Improved accuracy when matching stages across canvas updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->