### PR TITLE
fix(mcp): keep sync NAS I/O off the event loop (#367)

### DIFF
--- a/api/eagle.py
+++ b/api/eagle.py
@@ -40,7 +40,7 @@ async def eagle_status(request: web.Request) -> web.Response:
         return web.json_response({"enabled": False, "mode": "disabled",
                                   "pending": 0})
     status = await eagle.probe(fresh=request.query.get("fresh") == "1")
-    pending = storage.eagle_pending_count()
+    pending = await asyncio.to_thread(storage.eagle_pending_count)
     if status["mode"] == "api" and pending > 0:
         _autoflush()
     return web.json_response({"enabled": True, **status, "pending": pending})
@@ -137,12 +137,18 @@ async def _item_file(request: web.Request, thumb: bool):
     if not eagle_lib.valid_item_id(item_id):
         return web.json_response({"error": "invalid item id"}, status=400)
     status = await eagle.probe()
-    lib = eagle.library_for_reads(status)
-    if lib is None:
-        return web.json_response({"error": "no eagle library reachable"}, status=409)
     resolver = eagle_lib.item_thumb_file if thumb else eagle_lib.item_main_file
-    path = await asyncio.to_thread(resolver, lib, item_id)
+
+    def _resolve():
+        lib = eagle.library_for_reads(status)
+        if lib is None:
+            return None
+        return resolver(lib, item_id) or "missing"
+
+    path = await asyncio.to_thread(_resolve)
     if path is None:
+        return web.json_response({"error": "no eagle library reachable"}, status=409)
+    if path == "missing":
         return web.Response(status=404)
     if thumb:
         # Items without an Eagle thumbnail resolve to the original file —
@@ -197,7 +203,7 @@ async def eagle_import(request: web.Request) -> web.Response:
         return web.json_response({"error": "invalid item id"}, status=400)
 
     status = await eagle.probe()
-    lib = eagle.library_for_reads(status)
+    lib = await asyncio.to_thread(eagle.library_for_reads, status)
     if lib is None:
         return web.json_response({"error": "no eagle library reachable"}, status=409)
 

--- a/api/mcp_tools.py
+++ b/api/mcp_tools.py
@@ -1269,7 +1269,7 @@ async def _wait_stage(args: dict) -> dict:
     if after is not None:
         baseline = int(after)
     else:
-        row = storage.latest_output_by_uid(pid, uid)
+        row = await asyncio.to_thread(storage.latest_output_by_uid, pid, uid)
         baseline = int(row["id"]) if row else 0
 
     def _is_fresh(row) -> bool:
@@ -1284,7 +1284,7 @@ async def _wait_stage(args: dict) -> dict:
 
     t0 = time.monotonic()
     while True:
-        row = storage.latest_output_by_uid(pid, uid)
+        row = await asyncio.to_thread(storage.latest_output_by_uid, pid, uid)
         if _is_fresh(row):
             return {
                 "status": "done",

--- a/runners/eagle.py
+++ b/runners/eagle.py
@@ -72,7 +72,7 @@ async def probe(*, fresh: bool = False) -> dict:
             and now - _probe_cache["at"] < PROBE_CACHE_TTL_S:
         return _probe_cache["status"]
 
-    pinned = pinned_library()
+    pinned = await asyncio.to_thread(pinned_library)
     status: dict[str, Any] = {
         "online": False,
         "version": None,
@@ -115,7 +115,7 @@ async def probe(*, fresh: bool = False) -> dict:
             current and _norm_path(current) == _norm_path(pinned))):
         status["library_match"] = True
         status["mode"] = "api"
-    elif pinned and Path(pinned).is_dir():
+    elif pinned and await asyncio.to_thread(lambda: Path(pinned).is_dir()):
         status["mode"] = "disk"
 
     _probe_cache["at"] = now
@@ -209,7 +209,7 @@ async def list_items(status: dict, *, keyword: str = "", folder: str = "",
         items = [eagle_lib.normalize_item(r) for r in (raw or [])]
         return {"items": [i for i in items if i is not None], "total": None}
 
-    lib = library_for_reads(status)
+    lib = await asyncio.to_thread(library_for_reads, status)
     if lib is None:
         return {"items": [], "total": 0}
     items = await asyncio.to_thread(eagle_lib.read_items, lib)
@@ -263,7 +263,7 @@ async def list_folders(status: dict) -> list[dict]:
         out: list[dict] = []
         _flatten_api_folders(raw, None, 0, out)
         return out
-    lib = library_for_reads(status)
+    lib = await asyncio.to_thread(library_for_reads, status)
     if lib is None:
         return []
     return await asyncio.to_thread(eagle_lib.read_folders, lib)
@@ -363,7 +363,7 @@ async def send_or_queue(payload_url: str, *, name: str = "",
     from .. import storage
     from .media import view_url_to_path
 
-    path = view_url_to_path(payload_url)
+    path = await asyncio.to_thread(view_url_to_path, payload_url)
     if path is None:
         raise FileNotFoundError(payload_url)
     try:
@@ -371,7 +371,8 @@ async def send_or_queue(payload_url: str, *, name: str = "",
                        folder=folder)
         return {"sent": True}
     except EagleUnavailable as e:
-        row = storage.enqueue_eagle_send(
+        row = await asyncio.to_thread(
+            storage.enqueue_eagle_send,
             payload_url=payload_url, name=name, tags=tags,
             annotation=annotation, folder=folder)
         return {"sent": False, "queued": True, "pending": row,
@@ -383,25 +384,26 @@ async def flush_pending() -> dict:
     from .media import view_url_to_path
 
     async with _flush_lock:
-        rows = storage.list_eagle_pending()
+        rows = await asyncio.to_thread(storage.list_eagle_pending)
         sent = failed = 0
         for row in rows:
             try:
-                path = view_url_to_path(row["payload_url"])
+                path = await asyncio.to_thread(view_url_to_path, row["payload_url"])
                 if path is None:
                     raise FileNotFoundError(row["payload_url"])
                 await send_now(path, name=row["name"], tags=row["tags"],
                                annotation=row.get("annotation"),
                                folder=row.get("folder"))
-                storage.resolve_eagle_pending(row["id"])
+                await asyncio.to_thread(storage.resolve_eagle_pending, row["id"])
                 sent += 1
             except EagleUnavailable:
                 break
             except Exception as e:
-                storage.resolve_eagle_pending(row["id"], error=str(e))
+                await asyncio.to_thread(
+                    storage.resolve_eagle_pending, row["id"], error=str(e))
                 failed += 1
-        return {"sent": sent, "failed": failed,
-                "remaining": storage.eagle_pending_count()}
+        remaining = await asyncio.to_thread(storage.eagle_pending_count)
+        return {"sent": sent, "failed": failed, "remaining": remaining}
 
 
 AUTO_SEND_OUTPUT_TYPES = {"image", "video", "audio", "images"}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness during Eagle library lookups, file operations, imports, and pending-queue processing.
  * Prevented storage and filesystem activity from blocking asynchronous workflows.
* **Reliability**
  * Improved handling of unreachable libraries and missing item files during file resolution.
  * Preserved existing API behavior and return values while operations run more smoothly in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->