### PR TITLE
Fix Codex CLI --approve-for-me sandbox conflict

### DIFF
--- a/bot/codex.py
+++ b/bot/codex.py
@@ -391,8 +391,6 @@ class CodexCodeProvider(AgentProvider):
         flags += ["-c", 'approvals_reviewer="auto_review"']
         if turn.model:
             flags += ["-m", turn.model]
-        if not turn.resume_token:
-            flags += ["--sandbox", "workspace-write"]
 
         temp_files: list[str] = []
         for i, att in enumerate(turn.attachments):

--- a/tests/test_bot_codex.py
+++ b/tests/test_bot_codex.py
@@ -143,8 +143,7 @@ class TestCodexArgv:
         assert "--json" in argv
         assert "--skip-git-repo-check" in argv
         assert "--approve-for-me" in argv
-        assert "--sandbox" in argv
-        assert argv[argv.index("--sandbox") + 1] == "workspace-write"
+        assert "--sandbox" not in argv
         assert 'mcp_servers.comfytv.url="http://127.0.0.1:8188/comfytv/mcp"' in argv
         assert "mcp_servers.comfytv.tool_timeout_sec=600" in argv
         assert "features.shell_tool=false" in argv


### PR DESCRIPTION
## Summary

Fixes ComfyTV Bot failures with recent Codex CLI versions when starting a new Codex session.

ComfyTV currently passes both:

```text
--approve-for-me
--sandbox workspace-write

Recent Codex CLI versions treat these options as mutually exclusive because --approve-for-me already uses the workspace-write sandbox.

This causes new Bot conversations to fail immediately with:

error: the argument '--approve-for-me' cannot be used with '--sandbox <SANDBOX_MODE>'
Fix

Remove the explicit:

--sandbox workspace-write

argument for new Codex sessions.

--approve-for-me already routes approval requests through automatic review using the workspace-write sandbox, so the intended sandbox behavior is preserved.

This also makes new-session behavior consistent with the existing resume path, which already uses --approve-for-me without an explicit --sandbox argument.

Tested

Tested on:

Windows 11
Codex CLI 0.151.0
ComfyTV Codex Bot provider

Before the change:

Starting a new Codex Bot conversation fails during CLI argument parsing.

After the change:

New Codex Bot conversations start and work normally.
Resume behavior remains unchanged.
Updated the Codex argv unit test to verify that --sandbox is not passed together with --approve-for-me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated command execution so new conversations no longer apply the `workspace-write` sandbox setting.
  * Standardized command options across new and resumed conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->