### PR TITLE
feat: add Atlas Cloud agent provider

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,3 +1,8 @@
+from .atlas_cloud import AtlasCloudProvider  # noqa: F401
+from .claude_code import ClaudeCodeProvider  # noqa: F401
+from .codex import CodexCodeProvider  # noqa: F401
+from .comfyui_llm_provider import ComfyUiLlmProvider  # noqa: F401
+from .local_llm import LocalLlmProvider  # noqa: F401
 from .providers import (  # noqa: F401
     AgentProvider,
     BotEvent,
@@ -10,10 +15,6 @@ from .providers import (  # noqa: F401
     list_providers,
     register_provider,
 )
-from .claude_code import ClaudeCodeProvider  # noqa: F401
-from .codex import CodexCodeProvider  # noqa: F401
-from .comfyui_llm_provider import ComfyUiLlmProvider  # noqa: F401
-from .local_llm import LocalLlmProvider  # noqa: F401
 from .qwen_code import QwenCodeProvider  # noqa: F401
 
 register_provider(ClaudeCodeProvider())
@@ -21,3 +22,4 @@ register_provider(CodexCodeProvider())
 register_provider(QwenCodeProvider())
 register_provider(LocalLlmProvider())
 register_provider(ComfyUiLlmProvider())
+register_provider(AtlasCloudProvider())

--- a/bot/atlas_cloud.py
+++ b/bot/atlas_cloud.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+
+from .local_llm import LocalLlmProvider
+from .providers import ProviderStatus
+
+_DEFAULT_API_BASE = "https://api.atlascloud.ai/v1"
+_API_BASE_ENV = "ATLASCLOUD_API_BASE"
+_API_KEY_ENVS = ("ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY")
+
+
+class AtlasCloudProvider(LocalLlmProvider):
+    id = "atlas-cloud"
+    label = "Atlas Cloud"
+
+    def __init__(self, *, base_url: str | None = None,
+                 model: str | None = None) -> None:
+        super().__init__(base_url=base_url, model=model)
+
+    @staticmethod
+    def _api_key() -> str:
+        for name in _API_KEY_ENVS:
+            key = os.environ.get(name, "").strip()
+            if key:
+                return key
+        return ""
+
+    def _base_url(self) -> str:
+        if self._base_url_override is not None:
+            return self._base_url_override.rstrip("/")
+        return os.environ.get(
+            _API_BASE_ENV, _DEFAULT_API_BASE).strip().rstrip("/")
+
+    def _api_headers(self) -> dict:
+        headers = {"Content-Type": "application/json"}
+        key = self._api_key()
+        if key:
+            headers["Authorization"] = f"Bearer {key}"
+        return headers
+
+    def _lms_bin(self) -> str:
+        return ""
+
+    async def probe(self) -> ProviderStatus:
+        if not self._api_key():
+            return ProviderStatus(
+                available=False,
+                logged_in=False,
+                detail="set ATLASCLOUD_API_KEY in the ComfyTV environment",
+            )
+        return await super().probe()
+
+    async def list_models(self) -> list[str]:
+        if not self._api_key():
+            return []
+        return await super().list_models()

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -42,6 +42,12 @@ Provider isolation is per-engine: Claude Code runs with a strict per-turn MCP co
 
 The Local LLM provider needs no agent CLI at all: ComfyTV runs the agent loop itself against any OpenAI-compatible endpoint — LM Studio, llama.cpp's `llama-server`, vLLM, Ollama and friends. Point **Settings → Agent & MCP → Local LLM endpoint** at the server's base URL (e.g. `http://127.0.0.1:1234/v1`); the model dropdown suggestions come straight from the endpoint's `/models` list. Keyless local endpoints only — consistent with the no-stored-keys rule (a `COMFYTV_LOCAL_LLM_API_KEY` environment variable is honoured for LAN servers that insist on a token, but nothing is ever stored).
 
+For a hosted OpenAI-compatible option, select **Atlas Cloud** and set
+`ATLASCLOUD_API_KEY` in the environment that starts ComfyTV. The provider uses
+`https://api.atlascloud.ai/v1` by default, fetches the model dropdown from the
+live `/models` endpoint, and never stores the key. Set `ATLASCLOUD_API_BASE` to
+override the endpoint; `ATLAS_CLOUD_API_KEY` is accepted as a key alias.
+
 Details worth knowing:
 
 - Conversations replay from ComfyTV's own transcript (the endpoint holds no session), so history survives server restarts.

--- a/docs/bot.zh.md
+++ b/docs/bot.zh.md
@@ -42,6 +42,12 @@ Bot 不直接调用任何云端模型 API,ComfyTV 也永远不存 key。它驱�
 
 Local LLM 完全不需要 agent CLI:ComfyTV 自己跑 agent 循环,对接任何 OpenAI 兼容端点 — LM Studio、llama.cpp 的 `llama-server`、vLLM、Ollama 都行。把 **设置 → Agent 与 MCP → Local LLM 端点** 指向服务的 base URL(如 `http://127.0.0.1:1234/v1`),模型建议直接来自端点的 `/models` 真实列表。仅限免 key 的本地端点 — 与"不存 key"的铁律一致(局域网服务非要 token 的话,认 `COMFYTV_LOCAL_LLM_API_KEY` 环境变量,但永远不落库)。
 
+如需托管的 OpenAI-compatible 服务，可选择 **Atlas Cloud**，并在启动
+ComfyTV 的环境中设置 `ATLASCLOUD_API_KEY`。该 provider 默认使用
+`https://api.atlascloud.ai/v1`，从实时 `/models` 端点加载模型下拉列表，且不会
+存储密钥。可用 `ATLASCLOUD_API_BASE` 覆盖端点，也兼容
+`ATLAS_CLOUD_API_KEY` 这一密钥变量名。
+
 几个值得知道的细节:
 
 - 对话历史由 ComfyTV 自己的记录重放(端点不持有会话),重启服务器也不丢上下文。

--- a/tests/test_bot_atlas_cloud.py
+++ b/tests/test_bot_atlas_cloud.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from ComfyTV.bot.atlas_cloud import AtlasCloudProvider
+from ComfyTV.bot.providers import get_provider
+
+
+class TestConfig:
+    def test_default_base_url(self, monkeypatch):
+        monkeypatch.delenv("ATLASCLOUD_API_BASE", raising=False)
+        provider = AtlasCloudProvider()
+        assert provider._base_url() == "https://api.atlascloud.ai/v1"
+
+    def test_base_url_env_and_override(self, monkeypatch):
+        monkeypatch.setenv("ATLASCLOUD_API_BASE", "https://example.test/v1/")
+        assert AtlasCloudProvider()._base_url() == "https://example.test/v1"
+        provider = AtlasCloudProvider(base_url="https://override.test/v1/")
+        assert provider._base_url() == "https://override.test/v1"
+
+    def test_api_key_aliases(self, monkeypatch):
+        monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+        monkeypatch.setenv("ATLAS_CLOUD_API_KEY", "alias-key")
+        provider = AtlasCloudProvider()
+        assert provider._api_headers()["Authorization"] == \
+            "Bearer alias-key"
+
+        monkeypatch.setenv("ATLASCLOUD_API_KEY", "primary-key")
+        assert provider._api_headers()["Authorization"] == \
+            "Bearer primary-key"
+
+    async def test_probe_requires_api_key(self, monkeypatch):
+        monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+        monkeypatch.delenv("ATLAS_CLOUD_API_KEY", raising=False)
+        status = await AtlasCloudProvider().probe()
+        assert status.available is False
+        assert status.logged_in is False
+        assert "ATLASCLOUD_API_KEY" in status.detail
+
+    async def test_list_models_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+        monkeypatch.delenv("ATLAS_CLOUD_API_KEY", raising=False)
+        assert await AtlasCloudProvider().list_models() == []
+
+    def test_does_not_manage_local_models(self):
+        assert AtlasCloudProvider()._lms_bin() == ""
+
+
+def test_provider_is_registered():
+    provider = get_provider("atlas-cloud")
+    assert isinstance(provider, AtlasCloudProvider)
+    assert provider.label == "Atlas Cloud"


### PR DESCRIPTION
## Summary

- add Atlas Cloud as an optional agent provider using the existing OpenAI-compatible agent loop
- load the API key from the process environment and models from the live `/models` endpoint without storing credentials
- document setup in the English and Chinese bot guides

## Testing

- `uv run --python 3.11 --with pytest --with pytest-asyncio --with aiohttp pytest -q tests/test_bot_atlas_cloud.py tests/test_bot_local_llm.py` (22 passed)
- `uvx ruff check --select E4,E7,E9,F bot/atlas_cloud.py bot/__init__.py tests/test_bot_atlas_cloud.py`
- live Atlas Cloud tool-calling smoke: `openai/gpt-4.1-mini` returned a `server_info` function call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Atlas Cloud as a hosted OpenAI-compatible provider.
  * Supports API key configuration through environment variables, with endpoint overrides.
  * Automatically discovers available models from Atlas Cloud.
  * Atlas Cloud is now available alongside existing providers.

* **Documentation**
  * Added Atlas Cloud setup and configuration guidance in English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->